### PR TITLE
make additionalProperties true by default

### DIFF
--- a/packages/arri-validate/src/_index.ts
+++ b/packages/arri-validate/src/_index.ts
@@ -1,6 +1,5 @@
-import * as a from "./lib/_index";
+import * as a from "./lib/_namespace";
 export * from "./lib/_index";
 export * from "./adapter";
 export * from "./schemas";
-export * from "./lib/validation";
 export { a };

--- a/packages/arri-validate/src/compiler/parse.test.ts
+++ b/packages/arri-validate/src/compiler/parse.test.ts
@@ -53,3 +53,34 @@ it("parses arrays", () => {
         1, 2, 3, 4, 5,
     ]);
 });
+
+it("respects the additionalProperties option", () => {
+    const LooseSchema = a.compile(
+        a.object({
+            id: a.string(),
+            name: a.string(),
+        }),
+    );
+    const StrictSchema = a.compile(
+        a.object(
+            {
+                id: a.string(),
+                name: a.string(),
+            },
+            { additionalProperties: false },
+        ),
+    );
+    const input = {
+        id: "",
+        name: "",
+    };
+    const inputWithAdditionalFields = {
+        id: "",
+        name: "",
+        description: "",
+    };
+    expect(LooseSchema.safeParse(input).success);
+    expect(LooseSchema.safeParse(inputWithAdditionalFields).success);
+    expect(StrictSchema.safeParse(input).success);
+    expect(!StrictSchema.safeParse(inputWithAdditionalFields).success);
+});

--- a/packages/arri-validate/src/compiler/validate.test.ts
+++ b/packages/arri-validate/src/compiler/validate.test.ts
@@ -448,3 +448,30 @@ it("validates nullable discriminators", () => {
         }),
     );
 });
+
+it("uses additionalProperties properly", () => {
+    const LooseSchema = a.compile(
+        a.object({ id: a.string(), name: a.string() }),
+    );
+    const StrictSchema = a.compile(
+        a.object(
+            {
+                id: a.string(),
+                name: a.string(),
+            },
+            { additionalProperties: false },
+        ),
+    );
+    const input = {
+        id: "",
+        name: "",
+    };
+    const inputWithAdditionalFields = {
+        id: "",
+        name: "",
+    };
+    expect(LooseSchema.validate(input));
+    expect(LooseSchema.validate(inputWithAdditionalFields));
+    expect(StrictSchema.validate(input));
+    expect(!StrictSchema.validate(inputWithAdditionalFields));
+});

--- a/packages/arri-validate/src/lib/_index.ts
+++ b/packages/arri-validate/src/lib/_index.ts
@@ -4,18 +4,10 @@ export * from "./boolean";
 export * from "./discriminator";
 export * from "./enum";
 export * from "./modifiers";
+export * from "./numberConstants";
 export * from "./numbers";
 export * from "./object";
 export * from "./record";
 export * from "./string";
 export * from "./timestamp";
-export {
-    parse,
-    safeParse,
-    serialize,
-    validate,
-    coerce,
-    safeCoerce,
-} from "./validation";
-export { compile } from "../compile";
-export type { InferType as infer } from "../schemas";
+export * from "./validation";

--- a/packages/arri-validate/src/lib/_namespace.ts
+++ b/packages/arri-validate/src/lib/_namespace.ts
@@ -1,0 +1,34 @@
+// this barrel file is used for the exported "a" namespace
+export { any } from "./any";
+export { array } from "./array";
+export { boolean } from "./boolean";
+export { discriminator } from "./discriminator";
+export { stringEnum, enumerator } from "./enum";
+export { optional, nullable } from "./modifiers";
+export {
+    number,
+    int8,
+    int16,
+    int32,
+    int64,
+    uint8,
+    uint16,
+    uint32,
+    uint64,
+    float32,
+    float64,
+} from "./numbers";
+export { object, partial, pick, extend, omit } from "./object";
+export { record } from "./record";
+export { string } from "./string";
+export { timestamp } from "./timestamp";
+export {
+    parse,
+    safeParse,
+    serialize,
+    validate,
+    coerce,
+    safeCoerce,
+} from "./validation";
+export { compile } from "../compile";
+export type { InferType as infer } from "../schemas";

--- a/packages/arri-validate/src/lib/array.test.ts
+++ b/packages/arri-validate/src/lib/array.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 
 describe("Type Inference", () => {
     it("infers basic array types", () => {

--- a/packages/arri-validate/src/lib/boolean.test.ts
+++ b/packages/arri-validate/src/lib/boolean.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 describe("parsing", () => {
     const parse = (input: unknown) => a.safeParse(a.boolean(), input).success;
     it("accepts good input", () => {

--- a/packages/arri-validate/src/lib/discriminator.test.ts
+++ b/packages/arri-validate/src/lib/discriminator.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 
 const DiscriminatorSchema = a.discriminator("eventType", {
     USER_CREATED: a.object({

--- a/packages/arri-validate/src/lib/enum.test.ts
+++ b/packages/arri-validate/src/lib/enum.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 
 const UserRolesSchema = a.stringEnum(["admin", "standard"]);
 type UserRolesSchema = a.infer<typeof UserRolesSchema>;

--- a/packages/arri-validate/src/lib/enum.ts
+++ b/packages/arri-validate/src/lib/enum.ts
@@ -4,6 +4,8 @@ import {
     SCHEMA_METADATA,
 } from "../schemas";
 
+export const stringEnum = enumerator;
+
 /**
  * An enumeration of string values
  *
@@ -11,12 +13,12 @@ import {
  * https://jsontypedef.com/docs/jtd-in-5-minutes/#enum-schemas
  *
  * @example
- * const Schema = a.stringEnum(["A", "B"])
+ * const Schema = a.enumerator(["A", "B"])
  * a.validate(Schema, "A") // true
  * a.validate(Schema, "B") // true
  * a.validate(Schema, "C") // false
  */
-export function stringEnum<TKeys extends string, TValues extends TKeys[]>(
+export function enumerator<TKeys extends string, TValues extends TKeys[]>(
     values: TValues,
     opts: ASchemaOptions = {},
 ): AStringEnumSchema<TValues> {

--- a/packages/arri-validate/src/lib/modifiers.test.ts
+++ b/packages/arri-validate/src/lib/modifiers.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 
 describe("nullable", () => {
     describe("type inference", () => {

--- a/packages/arri-validate/src/lib/numbers.test.ts
+++ b/packages/arri-validate/src/lib/numbers.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 
 test("type inference", () => {
     const Num = a.number();

--- a/packages/arri-validate/src/lib/object.test.ts
+++ b/packages/arri-validate/src/lib/object.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 
 const UserSchema = a.object({
     id: a.string(),
@@ -200,35 +200,34 @@ describe("a.object()", () => {
                 favorites: a.optional(a.array(a.string())),
             }),
         );
-        expect(result).toBe(
-            JSON.stringify({
-                properties: {
-                    id: {
+        expect(JSON.parse(result)).toStrictEqual({
+            properties: {
+                id: {
+                    type: "string",
+                    metadata: {},
+                },
+                name: {
+                    type: "string",
+                    metadata: {},
+                    nullable: true,
+                },
+                createdAt: {
+                    type: "timestamp",
+                    metadata: {},
+                },
+            },
+            optionalProperties: {
+                favorites: {
+                    elements: {
                         type: "string",
                         metadata: {},
                     },
-                    name: {
-                        type: "string",
-                        metadata: {},
-                        nullable: true,
-                    },
-                    createdAt: {
-                        type: "timestamp",
-                        metadata: {},
-                    },
+                    metadata: {},
                 },
-                optionalProperties: {
-                    favorites: {
-                        elements: {
-                            type: "string",
-                            metadata: {},
-                        },
-                        metadata: {},
-                    },
-                },
-                metadata: {},
-            }),
-        );
+            },
+            additionalProperties: true,
+            metadata: {},
+        });
     });
     it("serializes a simple object", () => {
         const SimpleObject = a.object({
@@ -379,28 +378,29 @@ describe("a.pick()", () => {
         expect(!result.success);
     });
     it("produces jtd object schema with picked properties", () => {
-        expect(JSON.stringify(UserSubsetSchema)).toBe(
-            JSON.stringify({
-                properties: {
-                    name: {
-                        type: "string",
-                        metadata: {},
-                    },
-                    email: {
-                        type: "string",
-                        metadata: {},
-                        nullable: true,
-                    },
+        expect(JSON.parse(JSON.stringify(UserSubsetSchema))).toStrictEqual({
+            properties: {
+                name: {
+                    type: "string",
+                    metadata: {},
                 },
-                optionalProperties: {},
-                metadata: {},
-            }),
-        );
+                email: {
+                    type: "string",
+                    metadata: {},
+                    nullable: true,
+                },
+            },
+            optionalProperties: {},
+            additionalProperties: true,
+            metadata: {},
+        });
     });
 });
 
 describe("a.omit()", () => {
-    const UserSubsetSchema = a.omit(UserSchema, ["id", "isAdmin"]);
+    const UserSubsetSchema = a.omit(UserSchema, ["id", "isAdmin"], {
+        additionalProperties: false,
+    });
     type UserSubsetSchema = a.infer<typeof UserSubsetSchema>;
     const parse = (input: unknown) => a.safeParse(UserSubsetSchema, input);
     it("infers object with omitted fields", () => {
@@ -437,28 +437,27 @@ describe("a.omit()", () => {
         expect(badResult.success).toBe(false);
     });
     it("produces jtd schema without omitted properties", () => {
-        expect(JSON.stringify(UserSubsetSchema)).toBe(
-            JSON.stringify({
-                properties: {
-                    name: {
-                        type: "string",
-                        metadata: {},
-                    },
-                    email: {
-                        type: "string",
-                        metadata: {},
-                        nullable: true,
-                    },
+        expect(JSON.parse(JSON.stringify(UserSubsetSchema))).toStrictEqual({
+            properties: {
+                name: {
+                    type: "string",
+                    metadata: {},
                 },
-                optionalProperties: {
-                    createdAt: {
-                        type: "timestamp",
-                        metadata: {},
-                    },
+                email: {
+                    type: "string",
+                    metadata: {},
+                    nullable: true,
                 },
-                metadata: {},
-            }),
-        );
+            },
+            optionalProperties: {
+                createdAt: {
+                    type: "timestamp",
+                    metadata: {},
+                },
+            },
+            additionalProperties: false,
+            metadata: {},
+        });
     });
 });
 
@@ -548,33 +547,32 @@ describe("a.partial()", () => {
                 }),
             ),
         );
-        expect(result).toBe(
-            JSON.stringify({
-                properties: {},
-                optionalProperties: {
-                    id: {
-                        type: "string",
-                        metadata: {},
-                    },
-                    name: {
-                        type: "string",
-                        metadata: {},
-                        nullable: true,
-                    },
-                    createdAt: {
-                        type: "timestamp",
-                        metadata: {},
-                    },
-                    favorites: {
-                        elements: {
-                            type: "string",
-                            metadata: {},
-                        },
-                        metadata: {},
-                    },
+        expect(JSON.parse(result)).toStrictEqual({
+            properties: {},
+            optionalProperties: {
+                id: {
+                    type: "string",
+                    metadata: {},
                 },
-                metadata: {},
-            }),
-        );
+                name: {
+                    type: "string",
+                    metadata: {},
+                    nullable: true,
+                },
+                createdAt: {
+                    type: "timestamp",
+                    metadata: {},
+                },
+                favorites: {
+                    elements: {
+                        type: "string",
+                        metadata: {},
+                    },
+                    metadata: {},
+                },
+            },
+            additionalProperties: true,
+            metadata: {},
+        });
     });
 });

--- a/packages/arri-validate/src/lib/object.ts
+++ b/packages/arri-validate/src/lib/object.ts
@@ -36,6 +36,10 @@ export function object<
 > {
     const schema: SchemaFormProperties = {
         properties: {},
+        additionalProperties:
+            typeof opts.additionalProperties === "boolean"
+                ? opts.additionalProperties
+                : true,
     };
     for (const key of Object.keys(input)) {
         const prop = input[key];
@@ -127,6 +131,9 @@ function parse<T>(
             }
         }
     }
+    if (data.errors.length) {
+        return undefined;
+    }
     if (data.discriminatorKey) {
         result[data.discriminatorKey] = data.discriminatorValue;
     }
@@ -186,9 +193,11 @@ function validate(schema: AObjectSchema, input: unknown): boolean {
         if (!prop && !schema.additionalProperties) {
             return false;
         }
-        const isValid = prop.metadata[SCHEMA_METADATA].validate(input[key]);
-        if (!isValid) {
-            return false;
+        if (prop) {
+            const isValid = prop.metadata[SCHEMA_METADATA].validate(input[key]);
+            if (!isValid) {
+                return false;
+            }
         }
     }
     return true;
@@ -218,6 +227,10 @@ export function pick<
     const schema: SchemaFormProperties = {
         properties: {},
         nullable: inputSchema.nullable,
+        additionalProperties:
+            typeof opts.additionalProperties === "boolean"
+                ? opts.additionalProperties
+                : true,
     };
 
     Object.keys(inputSchema.properties).forEach((key) => {
@@ -240,10 +253,6 @@ export function pick<
             }
         });
     }
-    if (typeof inputSchema.additionalProperties === "boolean") {
-        schema.additionalProperties = inputSchema.additionalProperties;
-    }
-
     return {
         ...(schema as any),
         metadata: {
@@ -294,6 +303,10 @@ export function omit<
             ...inputSchema.properties,
         },
         nullable: inputSchema.nullable,
+        additionalProperties:
+            typeof opts.additionalProperties === "boolean"
+                ? opts.additionalProperties
+                : true,
     };
     Object.keys(inputSchema.properties).forEach((key) => {
         if (keys.includes(key as any)) {
@@ -315,9 +328,6 @@ export function omit<
                 delete schema.optionalProperties[key];
             }
         });
-    }
-    if (typeof inputSchema.additionalProperties === "boolean") {
-        schema.additionalProperties = inputSchema.additionalProperties;
     }
     return {
         ...(schema as any),
@@ -406,7 +416,10 @@ export function extend<
             ...baseSchema.optionalProperties,
             ...inputSchema.optionalProperties,
         },
-        additionalProperties: opts.additionalProperties,
+        additionalProperties:
+            typeof opts.additionalProperties === "boolean"
+                ? opts.additionalProperties
+                : true,
     };
 
     const isType = (
@@ -444,7 +457,10 @@ export function partial<
     const newSchema: SchemaFormProperties = {
         properties: {},
         optionalProperties: {},
-        additionalProperties: schema.additionalProperties,
+        additionalProperties:
+            typeof options.additionalProperties === "boolean"
+                ? options.additionalProperties
+                : true,
         nullable: schema.nullable,
     };
     for (const key of Object.keys(schema.properties)) {

--- a/packages/arri-validate/src/lib/record.test.ts
+++ b/packages/arri-validate/src/lib/record.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 
 const NumberRecordSchema = a.record(a.int32());
 type NumberRecordSchema = a.infer<typeof NumberRecordSchema>;

--- a/packages/arri-validate/src/lib/string.test.ts
+++ b/packages/arri-validate/src/lib/string.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 
 describe("parsing", () => {
     const parse = (input: unknown) => a.safeParse(a.string(), input).success;

--- a/packages/arri-validate/src/lib/timestamp.test.ts
+++ b/packages/arri-validate/src/lib/timestamp.test.ts
@@ -1,4 +1,4 @@
-import * as a from "./_index";
+import * as a from "./_namespace";
 
 it("infers types", () => {
     const Timestamp = a.timestamp();

--- a/packages/arri-validate/src/testSuites.ts
+++ b/packages/arri-validate/src/testSuites.ts
@@ -651,4 +651,57 @@ export const testSuites: Record<
             { id: "1" },
         ],
     },
+    "object with additionalProperties false": {
+        schema: a.object(
+            {
+                id: a.string(),
+                name: a.string(),
+            },
+            { additionalProperties: false },
+        ),
+        goodInputs: [
+            {
+                id: "1",
+                name: "john",
+            },
+        ],
+        badInputs: [
+            {
+                id: "1",
+                name: "john",
+                createdAt: new Date(),
+            },
+            {
+                id: "1",
+                name: "john",
+                description: "",
+            },
+            {},
+            null,
+            true,
+        ],
+    },
+    "object with additionalProperties true": {
+        schema: a.object(
+            {
+                id: a.string(),
+                name: a.string(),
+            },
+            { additionalProperties: true },
+        ),
+        goodInputs: [
+            {
+                id: "",
+                name: "",
+                description: "",
+            },
+            {
+                id: "",
+                name: "",
+                description: "",
+                createdAt: new Date(),
+            },
+        ],
+        badInputs: [{}, null, { id: "" }],
+    },
 };

--- a/packages/json-schema-to-jtd/src/index.test.ts
+++ b/packages/json-schema-to-jtd/src/index.test.ts
@@ -67,7 +67,7 @@ it("Converts objects", () => {
                 metadata: emptyMetadata,
             },
         },
-        additionalProperties: undefined,
+        additionalProperties: true,
         metadata: emptyMetadata,
     };
     expect(jsonSchemaToJtdSchema(input)).toStrictEqual(expectedOutput);
@@ -99,7 +99,7 @@ it("Converts objects with optional values", () => {
                 metadata: emptyMetadata,
             },
         },
-        additionalProperties: undefined,
+        additionalProperties: true,
         metadata: emptyMetadata,
     };
     expect(jsonSchemaToJtdSchema(input)).toStrictEqual(expectedOutput);

--- a/packages/json-schema-to-jtd/src/index.ts
+++ b/packages/json-schema-to-jtd/src/index.ts
@@ -110,7 +110,10 @@ export function jsonSchemaScalarToJtdScalar(
 export function jsonSchemaObjectToJtdObject(input: JsonSchemaObject): Schema {
     const result: SchemaFormProperties = {
         properties: {},
-        additionalProperties: input.additionalProperties,
+        additionalProperties:
+            typeof input.additionalProperties === "boolean"
+                ? input.additionalProperties
+                : true,
         metadata: {
             id: input.$id ?? input.title,
             description: input.description,


### PR DESCRIPTION
add test cases for parsing and validating objs with addtionalProperties make exports to "a" namespace more explicit