### PR TITLE
[Feature] Better Parsing and Serialization Errors

### DIFF
--- a/packages/arri-validate/benchmark/src/objects.ts
+++ b/packages/arri-validate/benchmark/src/objects.ts
@@ -285,6 +285,11 @@ void benny.suite(
     benny.add("Arri (Compiled)", () => {
         ArriUserValidator.serialize(input);
     }),
+    benny.add("Arri (Compiled) Validate and Serialize", () => {
+        if (ArriUserValidator.validate(input)) {
+            ArriUserValidator.serialize(input);
+        }
+    }),
     benny.add("Ajv - JTD (Compiled)", () => {
         AjvJtdUserSerializer(input);
     }),

--- a/packages/arri-validate/src/compiler/parse.ts
+++ b/packages/arri-validate/src/compiler/parse.ts
@@ -14,7 +14,7 @@ import {
     type SchemaFormDiscriminator,
     type SchemaFormEmpty,
 } from "jtd-utils";
-import { camelCase, pascalCase } from "scule";
+import { camelCase } from "scule";
 import {
     int16Max,
     int16Min,
@@ -32,26 +32,9 @@ import {
 import { type TemplateInput } from "./common";
 
 export function createParsingTemplate(input: string, schema: Schema): string {
-    const validationErrorName = `$ValidationError${pascalCase(
-        schema.metadata?.id ?? input,
-    )}`;
-    const fallbackTemplate = `    class ${validationErrorName} extends Error {
-        errors;
-        constructor(input) {
-            super(input.message);
-            this.errors = input.errors;
-        }
-    }
-
-    function $fallback(instancePath, schemaPath, message) {
-        throw new ${validationErrorName}({ 
-            message: message,
-            errors: [{ 
-                instancePath: instancePath,
-                schemaPath: schemaPath,
-                message: message 
-            }],
-        });
+    const fallbackTemplate = `
+    function $fallback(instancePath, schemaPath) {
+        throw new Error(\`Error parsing input. InstancePath: "\${instancePath}". SchemaPath: "\${schemaPath}"\`);
     }`;
     let jsonParseCheck = "";
 

--- a/packages/arri-validate/src/lib/_namespace.ts
+++ b/packages/arri-validate/src/lib/_namespace.ts
@@ -29,6 +29,7 @@ export {
     validate,
     coerce,
     safeCoerce,
+    errors,
 } from "./validation";
 export { compile } from "../compile";
 export type { InferType as infer } from "../schemas";

--- a/packages/arri-validate/src/lib/array.test.ts
+++ b/packages/arri-validate/src/lib/array.test.ts
@@ -68,7 +68,7 @@ describe("Type Inference", () => {
     });
 });
 
-test("Parsing", () => {
+describe("Parsing", () => {
     const StringArray = a.array(a.string());
     const NumberArray = a.array(a.number());
     const ObjectArray = a.array(

--- a/packages/arri-validate/src/lib/array.ts
+++ b/packages/arri-validate/src/lib/array.ts
@@ -74,7 +74,7 @@ function parse<T>(
         } catch (err) {
             data.errors.push({
                 instancePath: data.instancePath,
-                schemaPath: data.schemaPath,
+                schemaPath: `${data.schemaPath}/elements`,
                 message: `Error at ${data.instancePath}. Invalid JSON.`,
             });
             return undefined;
@@ -83,7 +83,7 @@ function parse<T>(
     if (!Array.isArray(parsedInput)) {
         data.errors.push({
             instancePath: data.instancePath,
-            schemaPath: data.schemaPath,
+            schemaPath: `${data.schemaPath}/elements`,
             message: `Error at ${
                 data.instancePath
             }. Expected array. Got ${typeof input}.`,
@@ -102,9 +102,9 @@ function parse<T>(
                     errors: data.errors,
                 },
             );
-            if (data.errors.length) {
-                return undefined;
-            }
+            // if (data.errors.length) {
+            //     return undefined;
+            // }
             result.push(parsedItem as any);
         } else {
             const parsedItem = innerSchema.metadata[SCHEMA_METADATA].parse(
@@ -115,9 +115,9 @@ function parse<T>(
                     errors: data.errors,
                 },
             );
-            if (data.errors.length) {
-                return undefined;
-            }
+            // if (data.errors.length) {
+            //     return undefined;
+            // }
             result.push(parsedItem as any);
         }
     }

--- a/packages/arri-validate/src/lib/discriminator.ts
+++ b/packages/arri-validate/src/lib/discriminator.ts
@@ -146,13 +146,17 @@ function parse(
     coerce = false,
 ) {
     let parsedInput = input;
-    if (typeof input === "string" && data.instancePath.length === 0) {
+    if (
+        typeof input === "string" &&
+        input.length &&
+        data.instancePath.length === 0
+    ) {
         parsedInput = JSON.parse(input);
     }
     if (!isObject(parsedInput)) {
         data.errors.push({
             instancePath: data.instancePath,
-            schemaPath: data.schemaPath,
+            schemaPath: `${data.schemaPath}/discriminator`,
             message: `Error at ${
                 data.instancePath
             }. Expected object. Got ${typeof parsedInput}.`,

--- a/packages/arri-validate/src/lib/numbers.ts
+++ b/packages/arri-validate/src/lib/numbers.ts
@@ -289,7 +289,7 @@ function parseNumber(input: unknown, options: ValidationData) {
         if (Number.isNaN(result)) {
             options?.errors.push({
                 instancePath: options.instancePath,
-                schemaPath: options.schemaPath,
+                schemaPath: `${options.schemaPath}/type`,
                 message: `Error at ${options.instancePath}. Invalid number.`,
             });
             return undefined;
@@ -301,7 +301,7 @@ function parseNumber(input: unknown, options: ValidationData) {
     }
     options?.errors.push({
         instancePath: options.instancePath,
-        schemaPath: options.schemaPath,
+        schemaPath: `${options.schemaPath}/type`,
         message: `Error at ${options.instancePath}. Invalid number.`,
     });
     return undefined;
@@ -336,7 +336,7 @@ function numberScalarType<TType extends NumberType>(
                     if (typeof result !== "number") {
                         options?.errors.push({
                             instancePath: options.instancePath,
-                            schemaPath: options.schemaPath,
+                            schemaPath: `${options.schemaPath}/type`,
                             message: `Error at ${options.instancePath}. Invalid number.`,
                         });
                         return undefined;
@@ -347,7 +347,7 @@ function numberScalarType<TType extends NumberType>(
                     }
                     options?.errors.push({
                         instancePath: options.instancePath,
-                        schemaPath: options.schemaPath,
+                        schemaPath: `${options.schemaPath}/type`,
                         message: `Error at ${options.instancePath}. ${matchResult.message}`,
                     });
                     return undefined;
@@ -358,7 +358,7 @@ function numberScalarType<TType extends NumberType>(
                     if (typeof result !== "number") {
                         options.errors.push({
                             instancePath: options.instancePath,
-                            schemaPath: options.schemaPath,
+                            schemaPath: `${options.schemaPath}/type`,
                             message: `Error at ${
                                 options.instancePath
                             }. Unable to coerce ${typeof input} to ${type}.`,
@@ -371,7 +371,7 @@ function numberScalarType<TType extends NumberType>(
                     }
                     options.errors.push({
                         instancePath: options.instancePath,
-                        schemaPath: options.schemaPath,
+                        schemaPath: `${options.schemaPath}/type`,
                         message: `Error at ${options.instancePath}. ${matchResult.message}`,
                     });
                     return undefined;

--- a/packages/arri-validate/src/lib/object.ts
+++ b/packages/arri-validate/src/lib/object.ts
@@ -97,7 +97,7 @@ function parse<T>(
         } catch (err) {
             data.errors.push({
                 instancePath: data.instancePath,
-                schemaPath: data.schemaPath,
+                schemaPath: `${data.schemaPath}/properties`,
                 message: `Error at ${data.instancePath}. Invalid JSON.`,
             });
             return undefined;
@@ -106,7 +106,7 @@ function parse<T>(
     if (!isObject(parsedInput)) {
         data.errors.push({
             instancePath: data.instancePath,
-            schemaPath: data.schemaPath,
+            schemaPath: `${data.schemaPath}/properties`,
             message: `Error at ${data.instancePath}. Expected object`,
         });
     }
@@ -124,7 +124,7 @@ function parse<T>(
             ) {
                 data.errors.push({
                     instancePath: `${data.instancePath}/${key}`,
-                    schemaPath: `${data.schemaPath}/additionalKeys`,
+                    schemaPath: `${data.schemaPath}/additionalProperties`,
                     message: `Error at ${data.instancePath}/${key}. Key '${key}' is not included in the schema. To allow additional input properties set additionalProperties to 'true'.`,
                 });
             }

--- a/packages/arri-validate/src/lib/object.ts
+++ b/packages/arri-validate/src/lib/object.ts
@@ -109,6 +109,7 @@ function parse<T>(
             schemaPath: `${data.schemaPath}/properties`,
             message: `Error at ${data.instancePath}. Expected object`,
         });
+        return undefined;
     }
     const result: Record<any, any> = {};
     const optionalProps = schema.optionalProperties ?? {};

--- a/packages/arri-validate/src/lib/record.ts
+++ b/packages/arri-validate/src/lib/record.ts
@@ -90,7 +90,7 @@ function parse<T>(
     if (!isObject(parsedInput)) {
         data.errors.push({
             instancePath: data.instancePath,
-            schemaPath: data.schemaPath,
+            schemaPath: `${data.schemaPath}/values`,
             message: `Error at ${data.instancePath} Expected object`,
         });
         return undefined;

--- a/packages/arri-validate/src/lib/string.ts
+++ b/packages/arri-validate/src/lib/string.ts
@@ -2,7 +2,7 @@ import {
     type AScalarSchema,
     type ASchemaOptions,
     SCHEMA_METADATA,
-    type ValidationData,
+    type ValidationData as ValidationContext,
 } from "../schemas";
 
 /**
@@ -41,20 +41,20 @@ function validate(input: unknown): input is string {
     return typeof input === "string";
 }
 
-function parse(input: unknown, options: ValidationData) {
+function parse(input: unknown, context: ValidationContext) {
     if (validate(input)) {
         return input;
     }
-    options.errors.push({
-        instancePath: options.instancePath,
-        schemaPath: options.schemaPath,
+    context.errors.push({
+        instancePath: context.instancePath,
+        schemaPath: `${context.schemaPath}/type`,
         message: `Error at ${
-            options.instancePath
+            context.instancePath
         }. Expected 'string' got ${typeof input}.`,
     });
     return undefined;
 }
 
-function coerce(input: unknown, options: ValidationData) {
-    return parse(input, options);
+function coerce(input: unknown, context: ValidationContext) {
+    return parse(input, context);
 }

--- a/packages/arri-validate/src/lib/validation.test.ts
+++ b/packages/arri-validate/src/lib/validation.test.ts
@@ -32,3 +32,224 @@ describe("parsing test suites", () => {
         });
     }
 });
+
+describe("errors()", () => {
+    describe("scalar type errors", () => {
+        const schemas = [
+            a.string(),
+            a.boolean(),
+            a.int8(),
+            a.int16(),
+            a.int32(),
+            a.int64(),
+            a.uint8(),
+            a.uint16(),
+            a.uint32(),
+            a.uint64(),
+            a.timestamp(),
+        ];
+        for (const schema of schemas) {
+            test(schema.type, () => {
+                const result = a.errors(schema, null);
+                expect(result.length).toBe(1);
+                expect(result[0].schemaPath).toBe("/type");
+                expect(result[0].instancePath).toBe("");
+            });
+        }
+    });
+    test("nullable scalar type errors", () => {
+        const schema = a.nullable(a.string());
+        const result1 = a.errors(schema, null);
+        const result2 = a.errors(schema, "hello world");
+        const result3 = a.errors(schema, true);
+        expect(result1.length).toBe(0);
+        expect(result2.length).toBe(0);
+        expect(result3.length).toBe(1);
+        expect(result3[0].instancePath).toBe("");
+        expect(result3[0].schemaPath).toBe("/type");
+    });
+    test("enum errors", () => {
+        const schema = a.enumerator(["USER", "BOT"]);
+        const result1 = a.errors(schema, "USER");
+        const result2 = a.errors(schema, "BOT");
+        const result3 = a.errors(schema, "BLAH");
+        expect(result1.length).toBe(0);
+        expect(result2.length).toBe(0);
+        expect(result3.length).toBe(1);
+        expect(result3[0].schemaPath).toBe("/enum");
+        expect(result3[0].instancePath).toBe("");
+    });
+    test("object errors", () => {
+        const schema = a.object({
+            id: a.string(),
+            date: a.timestamp(),
+            role: a.enumerator(["USER", "BOT"]),
+        });
+        const result1 = a.errors(schema, {
+            id: "1",
+            date: new Date(),
+            role: "USER",
+        });
+        const result2 = a.errors(schema, {
+            id: "1",
+            date: false,
+            role: "BOT",
+        });
+        const result3 = a.errors(schema, {
+            id: "1",
+            date: false,
+            role: "BLAH",
+        });
+        const result4 = a.errors(schema, true);
+        expect(result1.length).toBe(0);
+        expect(result2.length).toBe(1);
+        expect(result2[0].instancePath).toBe("/date");
+        expect(result2[0].schemaPath).toBe("/properties/date/type");
+        expect(result3.length).toBe(2);
+        expect(result3[0].instancePath).toBe("/date");
+        expect(result3[0].schemaPath).toBe("/properties/date/type");
+        expect(result3[1].instancePath).toBe("/role");
+        expect(result3[1].schemaPath).toBe("/properties/role/enum");
+        expect(result4.length).toBe(1);
+        expect(result4[0].instancePath).toBe("");
+        expect(result4[0].schemaPath).toBe("/properties");
+    });
+    test("optional object property errors", () => {
+        const schema = a.object({
+            id: a.string(),
+            date: a.optional(a.timestamp()),
+        });
+        const result1 = a.errors(schema, {
+            id: "1",
+        });
+        const result2 = a.errors(schema, {
+            id: "1",
+            date: true,
+        });
+        expect(result1.length).toBe(0);
+        expect(result2.length).toBe(1);
+        expect(result2[0].instancePath).toBe("/date");
+        expect(result2[0].schemaPath).toBe("/optionalProperties/date/type");
+    });
+    test("object strict additional field errors", () => {
+        const looseSchema = a.object({
+            id: a.string(),
+            date: a.timestamp(),
+        });
+        const strictSchema = a.object(
+            {
+                id: a.string(),
+                date: a.timestamp(),
+            },
+            { additionalProperties: false },
+        );
+        const looseResult = a.errors(looseSchema, {
+            id: "1",
+            date: new Date(),
+            message: "hello world",
+        });
+        const strictResult = a.errors(strictSchema, {
+            id: "1",
+            date: new Date(),
+            message: "hello world",
+        });
+        expect(looseResult.length).toBe(0);
+        expect(strictResult.length).toBe(1);
+        expect(strictResult[0].instancePath).toBe("/message");
+        expect(strictResult[0].schemaPath).toBe("/additionalProperties");
+    });
+    test("record errors", () => {
+        const schema = a.record(
+            a.object({ id: a.string(), date: a.timestamp() }),
+        );
+        const result1 = a.errors(schema, {});
+        const result2 = a.errors(schema, null);
+        const result3 = a.errors(schema, {
+            "1": {
+                id: "1",
+                date: new Date(),
+            },
+            "2": {
+                id: "2",
+                date: new Date(),
+            },
+        });
+        const result4 = a.errors(schema, {
+            "1": {
+                id: "1",
+                date: new Date(),
+            },
+            "2": {
+                id: 2,
+                date: new Date(),
+            },
+        });
+        expect(result1.length).toBe(0);
+        expect(result2.length).toBe(1);
+        expect(result2[0].instancePath).toBe("");
+        expect(result2[0].schemaPath).toBe("/values");
+        expect(result3.length).toBe(0);
+        expect(result4.length).toBe(1);
+        expect(result4[0].instancePath).toBe("/2/id");
+        expect(result4[0].schemaPath).toBe("/values/properties/id/type");
+    });
+    test("array errors", () => {
+        const schema = a.array(a.boolean());
+        const result1 = a.errors(schema, []);
+        const result2 = a.errors(schema, [true, false]);
+        const result3 = a.errors(schema, ["true", "false"]);
+        const result4 = a.errors(schema, null);
+        expect(result1.length).toBe(0);
+        expect(result2.length).toBe(0);
+        expect(result3.length).toBe(2);
+        expect(result3[0].instancePath).toBe("/0");
+        expect(result3[0].schemaPath).toBe("/elements/type");
+        expect(result3[1].instancePath).toBe("/1");
+        expect(result3[1].schemaPath).toBe("/elements/type");
+        expect(result4.length).toBe(1);
+        expect(result4[0].instancePath).toBe("");
+        expect(result4[0].schemaPath).toBe("/elements");
+    });
+    test("discriminator errors", () => {
+        const schema = a.discriminator("messageType", {
+            TEXT: a.object({
+                id: a.string(),
+                text: a.string(),
+            }),
+            IMAGE: a.object({
+                id: a.string(),
+                imageUrl: a.string(),
+            }),
+            VIDEO: a.object({
+                id: a.string(),
+                videoUrl: a.string(),
+            }),
+        });
+        const result1 = a.errors(schema, {
+            messageType: "LINK",
+        });
+        const result2 = a.errors(schema, {
+            id: "1",
+            messageType: "IMAGE",
+            text: "Hello world",
+        });
+        const result3 = a.errors(schema, {
+            id: "1",
+            messageType: "IMAGE",
+            imageUrl: "https://example.com",
+        });
+        const result4 = a.errors(schema, "");
+        expect(result1.length).toBe(1);
+        expect(result1[0].instancePath).toBe("/messageType");
+        expect(result1[0].schemaPath).toBe("/discriminator");
+        expect(result2.length).toBe(1);
+        expect(result2[0].instancePath).toBe("/imageUrl");
+        expect(result2[0].schemaPath).toBe(
+            "/mapping/IMAGE/properties/imageUrl/type",
+        );
+        expect(result3.length).toBe(0);
+        expect(result4.length).toBe(1);
+        expect(result4[0].instancePath).toBe("");
+        expect(result4[0].schemaPath).toBe("/discriminator");
+    });
+});

--- a/packages/arri-validate/src/lib/validation.ts
+++ b/packages/arri-validate/src/lib/validation.ts
@@ -124,6 +124,16 @@ export function serialize<T = any>(schema: ASchema<T>, input: T) {
     return schema.metadata[SCHEMA_METADATA].serialize(input, data);
 }
 
+export function errors(schema: ASchema, input: unknown): ValueError[] {
+    const errorList: ValueError[] = [];
+    schema.metadata[SCHEMA_METADATA].parse(input, {
+        errors: errorList,
+        instancePath: "",
+        schemaPath: "",
+    });
+    return errorList;
+}
+
 export interface ValueError {
     instancePath: string;
     schemaPath: string;

--- a/packages/arri/src/rpc.ts
+++ b/packages/arri/src/rpc.ts
@@ -285,6 +285,15 @@ export function registerRpc(
                 await opts.onBeforeResponse(event);
             }
             if (typeof response === "object") {
+                if (!responseValidator?.validate(response)) {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                    const errors = a.errors(procedure.response, response);
+                    throw defineError(500, {
+                        statusMessage:
+                            "Failed to serialize response. Response does not match specified schema",
+                        data: errors,
+                    });
+                }
                 setResponseHeader(event, "Content-Type", "application/json");
                 await send(
                     event,

--- a/tests/clients/client-typescript/testClient.rpc.ts
+++ b/tests/clients/client-typescript/testClient.rpc.ts
@@ -238,25 +238,10 @@ export interface ManuallyAddedModel {
 }
 const $$ManuallyAddedModel = {
     parse(input: Record<any, any>): ManuallyAddedModel {
-        class $ValidationErrorManuallyAddedModel extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorManuallyAddedModel({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -300,9 +285,7 @@ const $$ManuallyAddedModel = {
     serialize(input: ManuallyAddedModel): string {
         let json = "";
         json += "{";
-        json += `"hello":"${input.hello
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"hello":"${input.hello.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         return json;
     },
@@ -320,25 +303,10 @@ export interface AdaptersTypeboxAdapterParams {
 }
 const $$AdaptersTypeboxAdapterParams = {
     parse(input: Record<any, any>): AdaptersTypeboxAdapterParams {
-        class $ValidationErrorAdaptersTypeboxAdapterParams extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorAdaptersTypeboxAdapterParams({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -603,9 +571,7 @@ const $$AdaptersTypeboxAdapterParams = {
     serialize(input: AdaptersTypeboxAdapterParams): string {
         let json = "";
         json += "{";
-        json += `"string":"${input.string
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"string":"${input.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += `,"boolean":${input.boolean}`;
 
         if (Number.isNaN(input.integer)) {
@@ -619,9 +585,7 @@ const $$AdaptersTypeboxAdapterParams = {
         json += `,"number":${input.number}`;
         json += `,"enumField":"${input.enumField}"`;
         json += ',"object":{';
-        json += `"string":"${input.object.string
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"string":"${input.object.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         json += ',"array":[';
         for (let i = 0; i < input.array.length; i++) {
@@ -633,9 +597,7 @@ const $$AdaptersTypeboxAdapterParams = {
         }
         json += "]";
         if (typeof input.optionalString !== "undefined") {
-            json += `,"optionalString":"${input.optionalString
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
+            json += `,"optionalString":"${input.optionalString.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         }
         json += "}";
         return json;
@@ -651,25 +613,10 @@ export interface AdaptersTypeboxAdapterResponse {
 }
 const $$AdaptersTypeboxAdapterResponse = {
     parse(input: Record<any, any>): AdaptersTypeboxAdapterResponse {
-        class $ValidationErrorAdaptersTypeboxAdapterResponse extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorAdaptersTypeboxAdapterResponse({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -713,9 +660,7 @@ const $$AdaptersTypeboxAdapterResponse = {
     serialize(input: AdaptersTypeboxAdapterResponse): string {
         let json = "";
         json += "{";
-        json += `"message":"${input.message
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"message":"${input.message.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         return json;
     },
@@ -746,25 +691,10 @@ export interface ObjectWithEveryType {
 }
 const $$ObjectWithEveryType = {
     parse(input: Record<any, any>): ObjectWithEveryType {
-        class $ValidationErrorObjectWithEveryType extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorObjectWithEveryType({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -2046,9 +1976,7 @@ const $$ObjectWithEveryType = {
             json += '"any":' + JSON.stringify(input.any);
         }
         json += `,"boolean":${input.boolean}`;
-        json += `,"string":"${input.string
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `,"string":"${input.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += `,"timestamp":"${input.timestamp.toISOString()}"`;
 
         if (Number.isNaN(input.float32)) {
@@ -2103,9 +2031,7 @@ const $$ObjectWithEveryType = {
         }
         json += "]";
         json += ',"object":{';
-        json += `"string":"${input.object.string
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"string":"${input.object.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += `,"boolean":${input.object.boolean}`;
         json += `,"timestamp":"${input.object.timestamp.toISOString()}"`;
         json += "}";
@@ -2126,39 +2052,27 @@ const $$ObjectWithEveryType = {
             case "A": {
                 json += ',"discriminator":{';
                 json += `"type":"A"`;
-                json += `,"title":"${input.discriminator.title
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"title":"${input.discriminator.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += "}";
                 break;
             }
             case "B": {
                 json += ',"discriminator":{';
                 json += `"type":"B"`;
-                json += `,"title":"${input.discriminator.title
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
-                json += `,"description":"${input.discriminator.description
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"title":"${input.discriminator.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                json += `,"description":"${input.discriminator.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += "}";
                 break;
             }
         }
         json += ',"nestedObject":{';
-        json += `"id":"${input.nestedObject.id
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"id":"${input.nestedObject.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += `,"timestamp":"${input.nestedObject.timestamp.toISOString()}"`;
         json += ',"data":{';
-        json += `"id":"${input.nestedObject.data.id
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"id":"${input.nestedObject.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += `,"timestamp":"${input.nestedObject.data.timestamp.toISOString()}"`;
         json += ',"data":{';
-        json += `"id":"${input.nestedObject.data.data.id
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"id":"${input.nestedObject.data.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += `,"timestamp":"${input.nestedObject.data.data.timestamp.toISOString()}"`;
         json += "}";
         json += "}";
@@ -2176,9 +2090,7 @@ const $$ObjectWithEveryType = {
                     json += ",";
                 }
                 json += "{";
-                json += `"id":"${inputNestedArrayItemItem.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"id":"${inputNestedArrayItemItem.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${inputNestedArrayItemItem.timestamp.toISOString()}"`;
                 json += "}";
             }
@@ -2260,25 +2172,10 @@ export interface ObjectWithEveryNullableType {
 }
 const $$ObjectWithEveryNullableType = {
     parse(input: Record<any, any>): ObjectWithEveryNullableType {
-        class $ValidationErrorObjectWithEveryNullableType extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorObjectWithEveryNullableType({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -4002,9 +3899,7 @@ const $$ObjectWithEveryNullableType = {
             json += ',"boolean":null';
         }
         if (typeof input.string === "string") {
-            json += `,"string":"${input.string
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
+            json += `,"string":"${input.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         } else {
             json += ',"string":null';
         }
@@ -4115,9 +4010,7 @@ const $$ObjectWithEveryNullableType = {
         if (typeof input.object === "object" && input.object !== null) {
             json += ',"object":{';
             if (typeof input.object.string === "string") {
-                json += `"string":"${input.object.string
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"string":"${input.object.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             } else {
                 json += '"string":null';
             }
@@ -4168,9 +4061,7 @@ const $$ObjectWithEveryNullableType = {
                     json += ',"discriminator":{';
                     json += `"type":"A"`;
                     if (typeof input.discriminator.title === "string") {
-                        json += `,"title":"${input.discriminator.title
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"title":"${input.discriminator.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                     } else {
                         json += ',"title":null';
                     }
@@ -4181,16 +4072,12 @@ const $$ObjectWithEveryNullableType = {
                     json += ',"discriminator":{';
                     json += `"type":"B"`;
                     if (typeof input.discriminator.title === "string") {
-                        json += `,"title":"${input.discriminator.title
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"title":"${input.discriminator.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                     } else {
                         json += ',"title":null';
                     }
                     if (typeof input.discriminator.description === "string") {
-                        json += `,"description":"${input.discriminator.description
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"description":"${input.discriminator.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                     } else {
                         json += ',"description":null';
                     }
@@ -4207,9 +4094,7 @@ const $$ObjectWithEveryNullableType = {
         ) {
             json += ',"nestedObject":{';
             if (typeof input.nestedObject.id === "string") {
-                json += `"id":"${input.nestedObject.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"id":"${input.nestedObject.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             } else {
                 json += '"id":null';
             }
@@ -4227,9 +4112,7 @@ const $$ObjectWithEveryNullableType = {
             ) {
                 json += ',"data":{';
                 if (typeof input.nestedObject.data.id === "string") {
-                    json += `"id":"${input.nestedObject.data.id
-                        .replace(/[\n]/g, "\\n")
-                        .replace(/"/g, '\\"')}"`;
+                    json += `"id":"${input.nestedObject.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 } else {
                     json += '"id":null';
                 }
@@ -4247,9 +4130,7 @@ const $$ObjectWithEveryNullableType = {
                 ) {
                     json += ',"data":{';
                     if (typeof input.nestedObject.data.data.id === "string") {
-                        json += `"id":"${input.nestedObject.data.data.id
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `"id":"${input.nestedObject.data.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                     } else {
                         json += '"id":null';
                     }
@@ -4297,9 +4178,7 @@ const $$ObjectWithEveryNullableType = {
                             if (
                                 typeof inputNestedArrayItemItem.id === "string"
                             ) {
-                                json += `"id":"${inputNestedArrayItemItem.id
-                                    .replace(/[\n]/g, "\\n")
-                                    .replace(/"/g, '\\"')}"`;
+                                json += `"id":"${inputNestedArrayItemItem.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                             } else {
                                 json += '"id":null';
                             }
@@ -4402,25 +4281,10 @@ export interface ObjectWithEveryOptionalType {
 }
 const $$ObjectWithEveryOptionalType = {
     parse(input: Record<any, any>): ObjectWithEveryOptionalType {
-        class $ValidationErrorObjectWithEveryOptionalType extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorObjectWithEveryOptionalType({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -5932,13 +5796,9 @@ const $$ObjectWithEveryOptionalType = {
         }
         if (typeof input.string !== "undefined") {
             if (inputHasFields) {
-                json += `,"string":"${input.string
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"string":"${input.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             } else {
-                json += `"string":"${input.string
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"string":"${input.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 inputHasFields = true;
             }
         }
@@ -6113,17 +5973,13 @@ const $$ObjectWithEveryOptionalType = {
         if (typeof input.object !== "undefined") {
             if (inputHasFields) {
                 json += ',"object":{';
-                json += `"string":"${input.object.string
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"string":"${input.object.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"boolean":${input.object.boolean}`;
                 json += `,"timestamp":"${input.object.timestamp.toISOString()}"`;
                 json += "}";
             } else {
                 json += '"object":{';
-                json += `"string":"${input.object.string
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"string":"${input.object.string.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"boolean":${input.object.boolean}`;
                 json += `,"timestamp":"${input.object.timestamp.toISOString()}"`;
                 json += "}";
@@ -6168,21 +6024,15 @@ const $$ObjectWithEveryOptionalType = {
                     case "A": {
                         json += ',"discriminator":{';
                         json += `"type":"A"`;
-                        json += `,"title":"${input.discriminator.title
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"title":"${input.discriminator.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         json += "}";
                         break;
                     }
                     case "B": {
                         json += ',"discriminator":{';
                         json += `"type":"B"`;
-                        json += `,"title":"${input.discriminator.title
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
-                        json += `,"description":"${input.discriminator.description
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"title":"${input.discriminator.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                        json += `,"description":"${input.discriminator.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         json += "}";
                         break;
                     }
@@ -6192,21 +6042,15 @@ const $$ObjectWithEveryOptionalType = {
                     case "A": {
                         json += '"discriminator":{';
                         json += `"type":"A"`;
-                        json += `,"title":"${input.discriminator.title
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"title":"${input.discriminator.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         json += "}";
                         break;
                     }
                     case "B": {
                         json += '"discriminator":{';
                         json += `"type":"B"`;
-                        json += `,"title":"${input.discriminator.title
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
-                        json += `,"description":"${input.discriminator.description
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"title":"${input.discriminator.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                        json += `,"description":"${input.discriminator.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         json += "}";
                         break;
                     }
@@ -6217,38 +6061,26 @@ const $$ObjectWithEveryOptionalType = {
         if (typeof input.nestedObject !== "undefined") {
             if (inputHasFields) {
                 json += ',"nestedObject":{';
-                json += `"id":"${input.nestedObject.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"id":"${input.nestedObject.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.nestedObject.timestamp.toISOString()}"`;
                 json += ',"data":{';
-                json += `"id":"${input.nestedObject.data.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"id":"${input.nestedObject.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.nestedObject.data.timestamp.toISOString()}"`;
                 json += ',"data":{';
-                json += `"id":"${input.nestedObject.data.data.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"id":"${input.nestedObject.data.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.nestedObject.data.data.timestamp.toISOString()}"`;
                 json += "}";
                 json += "}";
                 json += "}";
             } else {
                 json += '"nestedObject":{';
-                json += `"id":"${input.nestedObject.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"id":"${input.nestedObject.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.nestedObject.timestamp.toISOString()}"`;
                 json += ',"data":{';
-                json += `"id":"${input.nestedObject.data.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"id":"${input.nestedObject.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.nestedObject.data.timestamp.toISOString()}"`;
                 json += ',"data":{';
-                json += `"id":"${input.nestedObject.data.data.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"id":"${input.nestedObject.data.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.nestedObject.data.data.timestamp.toISOString()}"`;
                 json += "}";
                 json += "}";
@@ -6272,9 +6104,7 @@ const $$ObjectWithEveryOptionalType = {
                             json += ",";
                         }
                         json += "{";
-                        json += `"id":"${inputNestedArrayItemItem.id
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `"id":"${inputNestedArrayItemItem.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         json += `,"timestamp":"${inputNestedArrayItemItem.timestamp.toISOString()}"`;
                         json += "}";
                     }
@@ -6296,9 +6126,7 @@ const $$ObjectWithEveryOptionalType = {
                             json += ",";
                         }
                         json += "{";
-                        json += `"id":"${inputNestedArrayItemItem.id
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `"id":"${inputNestedArrayItemItem.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         json += `,"timestamp":"${inputNestedArrayItemItem.timestamp.toISOString()}"`;
                         json += "}";
                     }
@@ -6363,25 +6191,10 @@ export interface AutoReconnectParams {
 }
 const $$AutoReconnectParams = {
     parse(input: Record<any, any>): AutoReconnectParams {
-        class $ValidationErrorAutoReconnectParams extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorAutoReconnectParams({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -6451,25 +6264,10 @@ export interface AutoReconnectResponse {
 }
 const $$AutoReconnectResponse = {
     parse(input: Record<any, any>): AutoReconnectResponse {
-        class $ValidationErrorAutoReconnectResponse extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorAutoReconnectResponse({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -6546,9 +6344,7 @@ const $$AutoReconnectResponse = {
             throw new Error("Expected number at /count got NaN");
         }
         json += `"count":${input.count}`;
-        json += `,"message":"${input.message
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `,"message":"${input.message.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         return json;
     },
@@ -6559,25 +6355,10 @@ export interface ChatMessageParams {
 }
 const $$ChatMessageParams = {
     parse(input: Record<any, any>): ChatMessageParams {
-        class $ValidationErrorChatMessageParams extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorChatMessageParams({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -6621,9 +6402,7 @@ const $$ChatMessageParams = {
     serialize(input: ChatMessageParams): string {
         let json = "";
         json += "{";
-        json += `"channelId":"${input.channelId
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"channelId":"${input.channelId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         return json;
     },
@@ -6632,25 +6411,10 @@ const $$ChatMessageParams = {
 export type ChatMessage = ChatMessageText | ChatMessageImage | ChatMessageUrl;
 const $$ChatMessage = {
     parse(input: Record<any, any>): ChatMessage {
-        class $ValidationErrorChatMessage extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorChatMessage({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -7053,57 +6817,33 @@ const $$ChatMessage = {
             case "TEXT": {
                 json += "{";
                 json += `"messageType":"TEXT"`;
-                json += `,"id":"${input.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
-                json += `,"channelId":"${input.channelId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
-                json += `,"userId":"${input.userId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"id":"${input.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                json += `,"channelId":"${input.channelId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                json += `,"userId":"${input.userId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"date":"${input.date.toISOString()}"`;
-                json += `,"text":"${input.text
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"text":"${input.text.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += "}";
                 break;
             }
             case "IMAGE": {
                 json += "{";
                 json += `"messageType":"IMAGE"`;
-                json += `,"id":"${input.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
-                json += `,"channelId":"${input.channelId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
-                json += `,"userId":"${input.userId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"id":"${input.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                json += `,"channelId":"${input.channelId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                json += `,"userId":"${input.userId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"date":"${input.date.toISOString()}"`;
-                json += `,"image":"${input.image
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"image":"${input.image.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += "}";
                 break;
             }
             case "URL": {
                 json += "{";
                 json += `"messageType":"URL"`;
-                json += `,"id":"${input.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
-                json += `,"channelId":"${input.channelId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
-                json += `,"userId":"${input.userId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"id":"${input.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                json += `,"channelId":"${input.channelId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                json += `,"userId":"${input.userId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"date":"${input.date.toISOString()}"`;
-                json += `,"url":"${input.url
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"url":"${input.url.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += "}";
                 break;
             }
@@ -7143,25 +6883,10 @@ export interface PostParams {
 }
 const $$PostParams = {
     parse(input: Record<any, any>): PostParams {
-        class $ValidationErrorPostParams extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorPostParams({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -7205,9 +6930,7 @@ const $$PostParams = {
     serialize(input: PostParams): string {
         let json = "";
         json += "{";
-        json += `"postId":"${input.postId
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"postId":"${input.postId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         return json;
     },
@@ -7227,25 +6950,10 @@ export interface Post {
 }
 const $$Post = {
     parse(input: Record<any, any>): Post {
-        class $ValidationErrorPost extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorPost({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -7655,48 +7363,30 @@ const $$Post = {
     serialize(input: Post): string {
         let json = "";
         json += "{";
-        json += `"id":"${input.id
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
-        json += `,"title":"${input.title
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"id":"${input.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+        json += `,"title":"${input.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += `,"type":"${input.type}"`;
         if (typeof input.description === "string") {
-            json += `,"description":"${input.description
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
+            json += `,"description":"${input.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         } else {
             json += ',"description":null';
         }
-        json += `,"content":"${input.content
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `,"content":"${input.content.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += ',"tags":[';
         for (let i = 0; i < input.tags.length; i++) {
             const inputTagsItem = input.tags[i];
             if (i !== 0) {
                 json += ",";
             }
-            json += `"${inputTagsItem
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
+            json += `"${inputTagsItem.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         }
         json += "]";
-        json += `,"authorId":"${input.authorId
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `,"authorId":"${input.authorId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += ',"author":{';
-        json += `"id":"${input.author.id
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
-        json += `,"name":"${input.author.name
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"id":"${input.author.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+        json += `,"name":"${input.author.name.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         if (typeof input.author.bio === "string") {
-            json += `,"bio":"${input.author.bio
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
+            json += `,"bio":"${input.author.bio.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         } else {
             json += ',"bio":null';
         }
@@ -7724,25 +7414,10 @@ export interface PostListParams {
 }
 const $$PostListParams = {
     parse(input: Record<any, any>): PostListParams {
-        class $ValidationErrorPostListParams extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorPostListParams({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -7865,25 +7540,10 @@ export interface PostListResponse {
 }
 const $$PostListResponse = {
     parse(input: Record<any, any>): PostListResponse {
-        class $ValidationErrorPostListResponse extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorPostListResponse({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -8584,48 +8244,30 @@ const $$PostListResponse = {
                 json += ",";
             }
             json += "{";
-            json += `"id":"${inputItemsItem.id
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
-            json += `,"title":"${inputItemsItem.title
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
+            json += `"id":"${inputItemsItem.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+            json += `,"title":"${inputItemsItem.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             json += `,"type":"${inputItemsItem.type}"`;
             if (typeof inputItemsItem.description === "string") {
-                json += `,"description":"${inputItemsItem.description
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"description":"${inputItemsItem.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             } else {
                 json += ',"description":null';
             }
-            json += `,"content":"${inputItemsItem.content
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
+            json += `,"content":"${inputItemsItem.content.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             json += ',"tags":[';
             for (let i = 0; i < inputItemsItem.tags.length; i++) {
                 const inputItemsItemTagsItem = inputItemsItem.tags[i];
                 if (i !== 0) {
                     json += ",";
                 }
-                json += `"${inputItemsItemTagsItem
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"${inputItemsItemTagsItem.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             }
             json += "]";
-            json += `,"authorId":"${inputItemsItem.authorId
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
+            json += `,"authorId":"${inputItemsItem.authorId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             json += ',"author":{';
-            json += `"id":"${inputItemsItem.author.id
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
-            json += `,"name":"${inputItemsItem.author.name
-                .replace(/[\n]/g, "\\n")
-                .replace(/"/g, '\\"')}"`;
+            json += `"id":"${inputItemsItem.author.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+            json += `,"name":"${inputItemsItem.author.name.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             if (typeof inputItemsItem.author.bio === "string") {
-                json += `,"bio":"${inputItemsItem.author.bio
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"bio":"${inputItemsItem.author.bio.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             } else {
                 json += ',"bio":null';
             }
@@ -8650,25 +8292,10 @@ export type PostEvent =
     | PostEventPostCommented;
 const $$PostEvent = {
     parse(input: Record<any, any>): PostEvent {
-        class $ValidationErrorPostEvent extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorPostEvent({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -9780,9 +9407,7 @@ const $$PostEvent = {
             case "POST_CREATED": {
                 json += "{";
                 json += `"eventType":"POST_CREATED"`;
-                json += `,"postId":"${input.postId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"postId":"${input.postId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.timestamp.toISOString()}"`;
                 json += "}";
                 break;
@@ -9790,9 +9415,7 @@ const $$PostEvent = {
             case "POST_DELETED": {
                 json += "{";
                 json += `"eventType":"POST_DELETED"`;
-                json += `,"postId":"${input.postId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"postId":"${input.postId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.timestamp.toISOString()}"`;
                 json += "}";
                 break;
@@ -9800,33 +9423,23 @@ const $$PostEvent = {
             case "POST_UPDATED": {
                 json += "{";
                 json += `"eventType":"POST_UPDATED"`;
-                json += `,"postId":"${input.postId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"postId":"${input.postId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.timestamp.toISOString()}"`;
                 json += ',"data":{';
                 let dataHasFields = false;
                 if (typeof input.data.id !== "undefined") {
                     if (dataHasFields) {
-                        json += `,"id":"${input.data.id
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"id":"${input.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                     } else {
-                        json += `"id":"${input.data.id
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `"id":"${input.data.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         dataHasFields = true;
                     }
                 }
                 if (typeof input.data.title !== "undefined") {
                     if (dataHasFields) {
-                        json += `,"title":"${input.data.title
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"title":"${input.data.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                     } else {
-                        json += `"title":"${input.data.title
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `"title":"${input.data.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         dataHasFields = true;
                     }
                 }
@@ -9841,17 +9454,13 @@ const $$PostEvent = {
                 if (typeof input.data.description !== "undefined") {
                     if (dataHasFields) {
                         if (typeof input.data.description === "string") {
-                            json += `,"description":"${input.data.description
-                                .replace(/[\n]/g, "\\n")
-                                .replace(/"/g, '\\"')}"`;
+                            json += `,"description":"${input.data.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         } else {
                             json += ',"description":null';
                         }
                     } else {
                         if (typeof input.data.description === "string") {
-                            json += `"description":"${input.data.description
-                                .replace(/[\n]/g, "\\n")
-                                .replace(/"/g, '\\"')}"`;
+                            json += `"description":"${input.data.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         } else {
                             json += '"description":null';
                         }
@@ -9860,13 +9469,9 @@ const $$PostEvent = {
                 }
                 if (typeof input.data.content !== "undefined") {
                     if (dataHasFields) {
-                        json += `,"content":"${input.data.content
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"content":"${input.data.content.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                     } else {
-                        json += `"content":"${input.data.content
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `"content":"${input.data.content.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         dataHasFields = true;
                     }
                 }
@@ -9878,9 +9483,7 @@ const $$PostEvent = {
                             if (i !== 0) {
                                 json += ",";
                             }
-                            json += `"${inputDataTagsItem
-                                .replace(/[\n]/g, "\\n")
-                                .replace(/"/g, '\\"')}"`;
+                            json += `"${inputDataTagsItem.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         }
                         json += "]";
                     } else {
@@ -9890,9 +9493,7 @@ const $$PostEvent = {
                             if (i !== 0) {
                                 json += ",";
                             }
-                            json += `"${inputDataTagsItem
-                                .replace(/[\n]/g, "\\n")
-                                .replace(/"/g, '\\"')}"`;
+                            json += `"${inputDataTagsItem.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         }
                         json += "]";
                         dataHasFields = true;
@@ -9900,29 +9501,19 @@ const $$PostEvent = {
                 }
                 if (typeof input.data.authorId !== "undefined") {
                     if (dataHasFields) {
-                        json += `,"authorId":"${input.data.authorId
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `,"authorId":"${input.data.authorId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                     } else {
-                        json += `"authorId":"${input.data.authorId
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `"authorId":"${input.data.authorId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         dataHasFields = true;
                     }
                 }
                 if (typeof input.data.author !== "undefined") {
                     if (dataHasFields) {
                         json += ',"author":{';
-                        json += `"id":"${input.data.author.id
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
-                        json += `,"name":"${input.data.author.name
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `"id":"${input.data.author.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                        json += `,"name":"${input.data.author.name.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         if (typeof input.data.author.bio === "string") {
-                            json += `,"bio":"${input.data.author.bio
-                                .replace(/[\n]/g, "\\n")
-                                .replace(/"/g, '\\"')}"`;
+                            json += `,"bio":"${input.data.author.bio.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         } else {
                             json += ',"bio":null';
                         }
@@ -9931,16 +9522,10 @@ const $$PostEvent = {
                         json += "}";
                     } else {
                         json += '"author":{';
-                        json += `"id":"${input.data.author.id
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
-                        json += `,"name":"${input.data.author.name
-                            .replace(/[\n]/g, "\\n")
-                            .replace(/"/g, '\\"')}"`;
+                        json += `"id":"${input.data.author.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                        json += `,"name":"${input.data.author.name.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         if (typeof input.data.author.bio === "string") {
-                            json += `,"bio":"${input.data.author.bio
-                                .replace(/[\n]/g, "\\n")
-                                .replace(/"/g, '\\"')}"`;
+                            json += `,"bio":"${input.data.author.bio.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                         } else {
                             json += ',"bio":null';
                         }
@@ -9973,13 +9558,9 @@ const $$PostEvent = {
             case "POST_LIKED": {
                 json += "{";
                 json += `"eventType":"POST_LIKED"`;
-                json += `,"postId":"${input.postId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"postId":"${input.postId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.timestamp.toISOString()}"`;
-                json += `,"postLikeId":"${input.postLikeId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"postLikeId":"${input.postLikeId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
 
                 if (Number.isNaN(input.postLikeCount)) {
                     throw new Error(
@@ -9993,16 +9574,10 @@ const $$PostEvent = {
             case "POST_COMMENTED": {
                 json += "{";
                 json += `"eventType":"POST_COMMENTED"`;
-                json += `,"postId":"${input.postId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"postId":"${input.postId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += `,"timestamp":"${input.timestamp.toISOString()}"`;
-                json += `,"commentId":"${input.commentId
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
-                json += `,"commentText":"${input.commentText
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"commentId":"${input.commentId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+                json += `,"commentText":"${input.commentText.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
 
                 if (Number.isNaN(input.commentCount)) {
                     throw new Error("Expected number at /commentCount got NaN");
@@ -10070,25 +9645,10 @@ export interface LogPostEventResponse {
 }
 const $$LogPostEventResponse = {
     parse(input: Record<any, any>): LogPostEventResponse {
-        class $ValidationErrorLogPostEventResponse extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorLogPostEventResponse({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -10151,9 +9711,7 @@ const $$LogPostEventResponse = {
         let json = "";
         json += "{";
         json += `"success":${input.success}`;
-        json += `,"message":"${input.message
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `,"message":"${input.message.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         return json;
     },
@@ -10165,25 +9723,10 @@ export interface UpdatePostParams {
 }
 const $$UpdatePostParams = {
     parse(input: Record<any, any>): UpdatePostParams {
-        class $ValidationErrorUpdatePostParams extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorUpdatePostParams({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -10398,37 +9941,27 @@ const $$UpdatePostParams = {
     serialize(input: UpdatePostParams): string {
         let json = "";
         json += "{";
-        json += `"postId":"${input.postId
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"postId":"${input.postId.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += ',"data":{';
         let dataHasFields = false;
         if (typeof input.data.title !== "undefined") {
             if (dataHasFields) {
-                json += `,"title":"${input.data.title
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"title":"${input.data.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             } else {
-                json += `"title":"${input.data.title
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"title":"${input.data.title.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 dataHasFields = true;
             }
         }
         if (typeof input.data.description !== "undefined") {
             if (dataHasFields) {
                 if (typeof input.data.description === "string") {
-                    json += `,"description":"${input.data.description
-                        .replace(/[\n]/g, "\\n")
-                        .replace(/"/g, '\\"')}"`;
+                    json += `,"description":"${input.data.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 } else {
                     json += ',"description":null';
                 }
             } else {
                 if (typeof input.data.description === "string") {
-                    json += `"description":"${input.data.description
-                        .replace(/[\n]/g, "\\n")
-                        .replace(/"/g, '\\"')}"`;
+                    json += `"description":"${input.data.description.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 } else {
                     json += '"description":null';
                 }
@@ -10437,13 +9970,9 @@ const $$UpdatePostParams = {
         }
         if (typeof input.data.content !== "undefined") {
             if (dataHasFields) {
-                json += `,"content":"${input.data.content
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"content":"${input.data.content.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
             } else {
-                json += `"content":"${input.data.content
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `"content":"${input.data.content.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 dataHasFields = true;
             }
         }
@@ -10455,9 +9984,7 @@ const $$UpdatePostParams = {
                     if (i !== 0) {
                         json += ",";
                     }
-                    json += `"${inputDataTagsItem
-                        .replace(/[\n]/g, "\\n")
-                        .replace(/"/g, '\\"')}"`;
+                    json += `"${inputDataTagsItem.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 }
                 json += "]";
             } else {
@@ -10467,9 +9994,7 @@ const $$UpdatePostParams = {
                     if (i !== 0) {
                         json += ",";
                     }
-                    json += `"${inputDataTagsItem
-                        .replace(/[\n]/g, "\\n")
-                        .replace(/"/g, '\\"')}"`;
+                    json += `"${inputDataTagsItem.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 }
                 json += "]";
                 dataHasFields = true;
@@ -10493,25 +10018,10 @@ export interface AnnotationId {
 }
 const $$AnnotationId = {
     parse(input: Record<any, any>): AnnotationId {
-        class $ValidationErrorAnnotationId extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorAnnotationId({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -10573,12 +10083,8 @@ const $$AnnotationId = {
     serialize(input: AnnotationId): string {
         let json = "";
         json += "{";
-        json += `"id":"${input.id
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
-        json += `,"version":"${input.version
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"id":"${input.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+        json += `,"version":"${input.version.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         return json;
     },
@@ -10594,25 +10100,10 @@ export interface Annotation {
 }
 const $$Annotation = {
     parse(input: Record<any, any>): Annotation {
-        class $ValidationErrorAnnotation extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorAnnotation({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -11045,18 +10536,12 @@ const $$Annotation = {
         let json = "";
         json += "{";
         json += '"annotation_id":{';
-        json += `"id":"${input.annotation_id.id
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
-        json += `,"version":"${input.annotation_id.version
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"id":"${input.annotation_id.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+        json += `,"version":"${input.annotation_id.version.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         json += ',"associated_id":{';
         json += `"entity_type":"${input.associated_id.entity_type}"`;
-        json += `,"id":"${input.associated_id.id
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `,"id":"${input.associated_id.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += "}";
         json += `,"annotation_type":"${input.annotation_type}"`;
 
@@ -11096,25 +10581,10 @@ export interface UpdateAnnotationParams {
 }
 const $$UpdateAnnotationParams = {
     parse(input: Record<any, any>): UpdateAnnotationParams {
-        class $ValidationErrorUpdateAnnotationParams extends Error {
-            errors;
-            constructor(input) {
-                super(input.message);
-                this.errors = input.errors;
-            }
-        }
-
-        function $fallback(instancePath, schemaPath, message) {
-            throw new $ValidationErrorUpdateAnnotationParams({
-                message: message,
-                errors: [
-                    {
-                        instancePath: instancePath,
-                        schemaPath: schemaPath,
-                        message: message,
-                    },
-                ],
-            });
+        function $fallback(instancePath, schemaPath) {
+            throw new Error(
+                `Error parsing input. InstancePath: "${instancePath}". SchemaPath: "${schemaPath}"`,
+            );
         }
 
         if (typeof input === "string") {
@@ -11610,28 +11080,20 @@ const $$UpdateAnnotationParams = {
     serialize(input: UpdateAnnotationParams): string {
         let json = "";
         json += "{";
-        json += `"annotation_id":"${input.annotation_id
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
-        json += `,"annotation_id_version":"${input.annotation_id_version
-            .replace(/[\n]/g, "\\n")
-            .replace(/"/g, '\\"')}"`;
+        json += `"annotation_id":"${input.annotation_id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
+        json += `,"annotation_id_version":"${input.annotation_id_version.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
         json += ',"data":{';
         let dataHasFields = false;
         if (typeof input.data.associated_id !== "undefined") {
             if (dataHasFields) {
                 json += ',"associated_id":{';
                 json += `"entity_type":"${input.data.associated_id.entity_type}"`;
-                json += `,"id":"${input.data.associated_id.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"id":"${input.data.associated_id.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += "}";
             } else {
                 json += '"associated_id":{';
                 json += `"entity_type":"${input.data.associated_id.entity_type}"`;
-                json += `,"id":"${input.data.associated_id.id
-                    .replace(/[\n]/g, "\\n")
-                    .replace(/"/g, '\\"')}"`;
+                json += `,"id":"${input.data.associated_id.id.replace(/[\n]/g, "\\n").replace(/"/g, '\\"')}"`;
                 json += "}";
                 dataHasFields = true;
             }


### PR DESCRIPTION
This PR brings the following changes:
- add an `a.errors` function which returns all of the parsing errors from an input.
- make it to where the arri rpc server automatically validates any returned input from the server to make sure it matches the `response` schema. 