### PR TITLE
Feature/id metadata shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,21 +53,13 @@ Arri comes with some useful helpers that reduces the boilerplate of manually cre
 import { createAppDefinition } from "arri/dist/codegen";
 import { a } from "arri-validate";
 
-const HelloParams = a.object(
-    {
-        message: a.string(),
-    },
-    { id: "HelloParams" },
-);
+const HelloParams = a.object("HelloParams", {
+    message: a.string(),
+});
 
-const HelloResponse = a.object(
-    {
-        message: a.string(),
-    },
-    {
-        id: "HelloResponse",
-    },
-);
+const HelloResponse = a.object("HelloResponse", {
+    message: a.string(),
+});
 
 export default createAppDefinition({
     procedures: {

--- a/README.md
+++ b/README.md
@@ -89,21 +89,13 @@ Additionally if you only need cross language types, you can skip defining proced
 import { createAppDefinition } from "arri/dist/codegen";
 import { a } from "arri-validate";
 
-const HelloParams = a.object(
-    {
-        message: a.string(),
-    },
-    { id: "HelloParams" },
-);
+const HelloParams = a.object("HelloParams", {
+    message: a.string(),
+});
 
-const HelloResponse = a.object(
-    {
-        message: a.string(),
-    },
-    {
-        id: "HelloResponse",
-    },
-);
+const HelloResponse = a.object("HelloResponse", {
+    message: a.string(),
+});
 
 export default createAppDefinition({
     models: {

--- a/packages/arri-codegen/utils/src/testModels.ts
+++ b/packages/arri-codegen/utils/src/testModels.ts
@@ -1,17 +1,12 @@
 import { a } from "arri-validate";
 import { type AppDefinition } from "./index";
 
-export const TestUserSettingsSchema = a.object(
-    {
-        notificationsEnabled: a.boolean(),
-        preferredTheme: a.stringEnum(["dark-mode", "light-mode", "system"], {
-            isDeprecated: true,
-        }),
-    },
-    {
-        id: "UserSettings",
-    },
-);
+export const TestUserSettingsSchema = a.object("UserSettings", {
+    notificationsEnabled: a.boolean(),
+    preferredTheme: a.stringEnum(["dark-mode", "light-mode", "system"], {
+        isDeprecated: true,
+    }),
+});
 
 export const TestUserPhotoSchema = a.object(
     {
@@ -27,6 +22,7 @@ export const TestUserPhotoSchema = a.object(
 );
 
 export const TestUserNotificationSchema = a.discriminator(
+    "UserNotification",
     "notificationType",
     {
         POST_LIKE: a.object({
@@ -39,43 +35,39 @@ export const TestUserNotificationSchema = a.discriminator(
             commentText: a.string(),
         }),
     },
-    { id: "UserNotification" },
 );
 
-export const TestUserSchema = a.object(
-    {
-        id: a.string(),
-        role: a.stringEnum(["standard", "admin"]),
-        photo: a.nullable(TestUserPhotoSchema),
-        createdAt: a.timestamp(),
-        numFollowers: a.int32(),
-        settings: TestUserSettingsSchema,
-        lastNotification: a.nullable(TestUserNotificationSchema),
-        recentNotifications: a.array(TestUserNotificationSchema),
-        bookmarks: a.record(
-            a.object({ postId: a.string(), userId: a.string() }),
-        ),
-        bio: a.optional(a.string()),
-        metadata: a.record(a.any()),
-        randomList: a.array(a.any()),
-        binaryTree: a.recursive(
-            (self) =>
-                a.object({
-                    left: a.nullable(self),
-                    right: a.nullable(self),
-                }),
-            { id: "BinaryTree" },
-        ),
-    },
-    { id: "User" },
-);
+interface BinaryTree {
+    left: BinaryTree | null;
+    right: BinaryTree | null;
+}
 
-export const TestUserParams = a.object(
-    {
-        userId: a.string(),
-    },
-    { id: "UserParams" },
-);
+export const TestUserSchema = a.object("User", {
+    id: a.string(),
+    role: a.stringEnum(["standard", "admin"]),
+    photo: a.nullable(TestUserPhotoSchema),
+    createdAt: a.timestamp(),
+    numFollowers: a.int32(),
+    settings: TestUserSettingsSchema,
+    lastNotification: a.nullable(TestUserNotificationSchema),
+    recentNotifications: a.array(TestUserNotificationSchema),
+    bookmarks: a.record(a.object({ postId: a.string(), userId: a.string() })),
+    bio: a.optional(a.string()),
+    metadata: a.record(a.any()),
+    randomList: a.array(a.any()),
+    binaryTree: a.recursive<BinaryTree>(
+        (self) =>
+            a.object({
+                left: a.nullable(self),
+                right: a.nullable(self),
+            }),
+        { id: "BinaryTree" },
+    ),
+});
+
+export const TestUserParams = a.object("UserParams", {
+    userId: a.string(),
+});
 
 export const TestUpdateUserParams = a.pick(
     TestUserSchema,
@@ -84,13 +76,6 @@ export const TestUpdateUserParams = a.pick(
         id: "UpdateUserParams",
     },
 );
-
-export const TestErrorResponse = a.object({
-    statusCode: a.int8(),
-    statusMessage: a.string(),
-    data: a.any(),
-    stack: a.nullable(a.string()),
-});
 
 export const TestAppDefinition: AppDefinition = {
     arriSchemaVersion: "0.0.4",

--- a/packages/arri-validate/README.md
+++ b/packages/arri-validate/README.md
@@ -733,6 +733,7 @@ Metadata is used during cross-language code generation. Arri schemas allow you t
 A schema with this metadata:
 
 ```ts
+// metadata object
 const BookSchema = a.object(
     {
         title: a.string(),
@@ -799,6 +800,39 @@ data class Book(
     val author: String,
     val publishDate: Instant,
 )
+```
+
+### ID Shorthand
+
+Because IDs are really important for producing consise type names. Arri validate also provides a shorthand for defining IDs of objects, discriminators, and recursive types.
+
+```ts
+// ID will be set to "Book"
+const BookSchema = a.object("Book", {
+    title: a.string(),
+    author: a.string(),
+    publishDate: a.timestamp(),
+});
+
+// ID will be set to "Message"
+const MessageSchema = a.discriminator("Message", "type", {
+    TEXT: a.object({
+        userId: a.string(),
+        content: a.string(),
+    }),
+    IMAGE: a.object({
+        userId: a.string(),
+        imageUrl: a.string(),
+    }),
+});
+
+// ID will be set to "BTree"
+const BinaryTreeSchema = a.recursive("BTree", (self) =>
+    a.object({
+        left: a.nullable(self),
+        right: a.nullable(self),
+    }),
+);
 ```
 
 ## Benchmarks

--- a/packages/arri-validate/src/lib/discriminator.ts
+++ b/packages/arri-validate/src/lib/discriminator.ts
@@ -51,7 +51,6 @@ export function discriminator<
     id: string,
     discriminator: TDiscriminatorKey,
     mapping: TMapping,
-    opts?: Omit<ASchemaOptions, "id">,
 ): ADiscriminatorSchema<
     InferDiscriminatorType<
         TDiscriminatorKey,
@@ -80,7 +79,6 @@ export function discriminator<
     propA: string | TDiscriminatorKey,
     propB: TDiscriminatorKey | TMapping,
     propC?: TMapping | ASchemaOptions,
-    propD?: ASchemaOptions,
 ): ADiscriminatorSchema<
     InferDiscriminatorType<
         TDiscriminatorKey,
@@ -91,7 +89,9 @@ export function discriminator<
     const isIdShorthand = typeof propB === "string";
     const discriminator = isIdShorthand ? propB : propA;
     const mapping = (isIdShorthand ? propC : propB) as TMapping;
-    const opts = (isIdShorthand ? propD ?? {} : propC ?? {}) as ASchemaOptions;
+    const opts = (
+        isIdShorthand ? { id: propA } : propC ?? {}
+    ) as ASchemaOptions;
     if (isIdShorthand) {
         opts.id = propA;
     }

--- a/packages/arri-validate/src/lib/discriminator.ts
+++ b/packages/arri-validate/src/lib/discriminator.ts
@@ -48,9 +48,39 @@ export function discriminator<
     TDiscriminatorKey extends string,
     TMapping extends Record<string, AObjectSchema<any>>,
 >(
+    id: string,
     discriminator: TDiscriminatorKey,
     mapping: TMapping,
-    opts: ASchemaOptions = {},
+    opts?: Omit<ASchemaOptions, "id">,
+): ADiscriminatorSchema<
+    InferDiscriminatorType<
+        TDiscriminatorKey,
+        TMapping,
+        JoinedDiscriminator<TDiscriminatorKey, TMapping>
+    >
+>;
+export function discriminator<
+    TDiscriminatorKey extends string,
+    TMapping extends Record<string, AObjectSchema<any>>,
+>(
+    discriminator: TDiscriminatorKey,
+    mapping: TMapping,
+    opts?: ASchemaOptions,
+): ADiscriminatorSchema<
+    InferDiscriminatorType<
+        TDiscriminatorKey,
+        TMapping,
+        JoinedDiscriminator<TDiscriminatorKey, TMapping>
+    >
+>;
+export function discriminator<
+    TDiscriminatorKey extends string,
+    TMapping extends Record<string, AObjectSchema<any>>,
+>(
+    propA: string | TDiscriminatorKey,
+    propB: TDiscriminatorKey | TMapping,
+    propC?: TMapping | ASchemaOptions,
+    propD?: ASchemaOptions,
 ): ADiscriminatorSchema<
     InferDiscriminatorType<
         TDiscriminatorKey,
@@ -58,6 +88,13 @@ export function discriminator<
         JoinedDiscriminator<TDiscriminatorKey, TMapping>
     >
 > {
+    const isIdShorthand = typeof propB === "string";
+    const discriminator = isIdShorthand ? propB : propA;
+    const mapping = (isIdShorthand ? propC : propB) as TMapping;
+    const opts = (isIdShorthand ? propD ?? {} : propC ?? {}) as ASchemaOptions;
+    if (isIdShorthand) {
+        opts.id = propA;
+    }
     return {
         discriminator,
         mapping,
@@ -87,7 +124,7 @@ export function discriminator<
                     return parse(discriminator, mapping, input, data, true);
                 },
                 serialize(input, data) {
-                    const discriminatorVal = input[discriminator];
+                    const discriminatorVal = input[discriminator] ?? "";
                     const targetSchema = mapping[discriminatorVal];
                     if (!targetSchema) {
                         throw discriminatorMappingError(discriminatorVal, data);

--- a/packages/arri-validate/src/lib/object.test.ts
+++ b/packages/arri-validate/src/lib/object.test.ts
@@ -273,6 +273,27 @@ describe("a.object()", () => {
         JSON.parse(result);
         expect(a.parse(NestedObject, result)).toStrictEqual(input);
     });
+    it("has consistent output across function overloads", () => {
+        const User1 = a.object(
+            {
+                id: a.string(),
+                name: a.string(),
+                createdAt: a.timestamp(),
+            },
+            {
+                id: "User",
+            },
+        );
+        const User2 = a.object("User", {
+            id: a.string(),
+            name: a.string(),
+            createdAt: a.timestamp(),
+        });
+        expect(JSON.stringify(User1)).toBe(JSON.stringify(User2));
+        const input = { id: "", name: "", createdAt: new Date() };
+        expect(a.validate(User1, input)).toEqual(a.validate(User2, input));
+        expect(a.serialize(User1, input)).toEqual(a.serialize(User2, input));
+    });
 });
 
 describe("a.object() -> Coersion", () => {

--- a/packages/arri-validate/src/lib/object.ts
+++ b/packages/arri-validate/src/lib/object.ts
@@ -16,7 +16,7 @@ import { optional } from "./modifiers";
  * Create an object schema
  *
  * @example
- * const Schema = a.object({
+ * const Schema = a.object('Schema', {
  *   foo: a.string(),
  *   bar: a.number()
  * });
@@ -27,12 +27,37 @@ export function object<
     TInput extends Record<any, ASchema> = any,
     TAdditionalProps extends boolean = false,
 >(
+    id: string,
     input: TInput,
-    opts: AObjectSchemaOptions<TAdditionalProps> = {},
+    opts?: Omit<AObjectSchemaOptions<TAdditionalProps>, "id">,
+): AObjectSchema<InferObjectOutput<TInput, TAdditionalProps>, TAdditionalProps>;
+export function object<
+    TInput extends Record<any, ASchema> = any,
+    TAdditionalProps extends boolean = false,
+>(
+    input: TInput,
+    opts?: AObjectSchemaOptions<TAdditionalProps>,
+): AObjectSchema<InferObjectOutput<TInput, TAdditionalProps>, TAdditionalProps>;
+export function object<
+    TInput extends Record<any, ASchema> = any,
+    TAdditionalProps extends boolean = false,
+>(
+    propA: TInput | string,
+    propB?: TInput | AObjectSchemaOptions<TAdditionalProps>,
+    propC?: AObjectSchemaOptions<TAdditionalProps>,
 ): AObjectSchema<
     InferObjectOutput<TInput, TAdditionalProps>,
     TAdditionalProps
 > {
+    const isIdShorthand = typeof propA === "string";
+    const id = isIdShorthand
+        ? propA
+        : (propB as AObjectSchemaOptions<TAdditionalProps> | undefined)?.id;
+    const input = isIdShorthand ? (propB as TInput) : propA;
+    const opts = isIdShorthand
+        ? propC ?? {}
+        : ((propB ?? {}) as AObjectSchemaOptions<TAdditionalProps>);
+    opts.id = id;
     const schema: SchemaFormProperties = {
         properties: {},
         additionalProperties:

--- a/packages/arri-validate/src/lib/object.ts
+++ b/packages/arri-validate/src/lib/object.ts
@@ -29,7 +29,6 @@ export function object<
 >(
     id: string,
     input: TInput,
-    opts?: Omit<AObjectSchemaOptions<TAdditionalProps>, "id">,
 ): AObjectSchema<InferObjectOutput<TInput, TAdditionalProps>, TAdditionalProps>;
 export function object<
     TInput extends Record<any, ASchema> = any,
@@ -44,20 +43,15 @@ export function object<
 >(
     propA: TInput | string,
     propB?: TInput | AObjectSchemaOptions<TAdditionalProps>,
-    propC?: AObjectSchemaOptions<TAdditionalProps>,
 ): AObjectSchema<
     InferObjectOutput<TInput, TAdditionalProps>,
     TAdditionalProps
 > {
     const isIdShorthand = typeof propA === "string";
-    const id = isIdShorthand
-        ? propA
-        : (propB as AObjectSchemaOptions<TAdditionalProps> | undefined)?.id;
     const input = isIdShorthand ? (propB as TInput) : propA;
     const opts = isIdShorthand
-        ? propC ?? {}
+        ? { id: propA }
         : ((propB ?? {}) as AObjectSchemaOptions<TAdditionalProps>);
-    opts.id = id;
     const schema: SchemaFormProperties = {
         properties: {},
         additionalProperties:

--- a/packages/arri-validate/src/lib/recursive.test.ts
+++ b/packages/arri-validate/src/lib/recursive.test.ts
@@ -203,3 +203,28 @@ describe("parsing", () => {
         }
     });
 });
+
+test("overloaded functions produce the same result", () => {
+    const SchemaA = a.recursive<BinaryTree>(
+        (self) => a.object({ left: a.nullable(self), right: a.nullable(self) }),
+        {
+            id: "BTree",
+        },
+    );
+    const SchemaB = a.recursive<BinaryTree>("BTree", (self) =>
+        a.object({ left: a.nullable(self), right: a.nullable(self) }),
+    );
+    expect(JSON.stringify(SchemaA)).toEqual(JSON.stringify(SchemaB));
+    const input: BinaryTree = {
+        left: {
+            left: null,
+            right: {
+                left: null,
+                right: null,
+            },
+        },
+        right: null,
+    };
+    expect(a.validate(SchemaA, input)).toBe(a.validate(SchemaB, input));
+    expect(a.serialize(SchemaA, input)).toBe(a.serialize(SchemaB, input));
+});

--- a/packages/arri-validate/src/lib/recursive.test.ts
+++ b/packages/arri-validate/src/lib/recursive.test.ts
@@ -14,6 +14,7 @@ const BinaryTree = a.recursive<BinaryTree>(
         id: "BinaryTree",
     },
 );
+
 type RecursiveUnion =
     | { type: "CHILD"; data: RecursiveUnion }
     | { type: "CHILDREN"; data: RecursiveUnion[] }

--- a/packages/arri-validate/src/lib/recursive.ts
+++ b/packages/arri-validate/src/lib/recursive.ts
@@ -33,7 +33,6 @@ type RecursiveCallback<T> = (
 export function recursive<T = any>(
     id: string,
     callback: RecursiveCallback<T>,
-    options?: Omit<ASchemaOptions, "id">,
 ): AObjectSchema<T> | ADiscriminatorSchema<T>;
 export function recursive<T = any>(
     callback: RecursiveCallback<T>,
@@ -42,16 +41,12 @@ export function recursive<T = any>(
 export function recursive<T = any>(
     propA: string | RecursiveCallback<T>,
     propB?: RecursiveCallback<T> | ASchemaOptions,
-    propC?: ASchemaOptions,
 ): AObjectSchema<T> | ADiscriminatorSchema<T> {
     const isIdShorthand = typeof propA === "string";
     const callback = isIdShorthand ? (propB as RecursiveCallback<T>) : propA;
     const options = isIdShorthand
-        ? propC ?? {}
+        ? { id: propA }
         : ((propB ?? {}) as ASchemaOptions);
-    if (isIdShorthand) {
-        options.id = propA;
-    }
     const recursiveFns: Record<
         string,
         {

--- a/packages/arri-validate/src/lib/recursive.ts
+++ b/packages/arri-validate/src/lib/recursive.ts
@@ -30,16 +30,16 @@ type RecursiveCallback<T> = (
  * );
  * ```
  */
-export function recursive<T>(
+export function recursive<T = any>(
     id: string,
     callback: RecursiveCallback<T>,
     options?: Omit<ASchemaOptions, "id">,
 ): AObjectSchema<T> | ADiscriminatorSchema<T>;
-export function recursive<T>(
+export function recursive<T = any>(
     callback: RecursiveCallback<T>,
     options?: ASchemaOptions,
 ): AObjectSchema<T> | ADiscriminatorSchema<T>;
-export function recursive<T>(
+export function recursive<T = any>(
     propA: string | RecursiveCallback<T>,
     propB?: RecursiveCallback<T> | ASchemaOptions,
     propC?: ASchemaOptions,

--- a/packages/arri-validate/src/testSuites.ts
+++ b/packages/arri-validate/src/testSuites.ts
@@ -75,6 +75,7 @@ export type RecursiveUnion =
     | { type: "TEXT"; data: string }
     | { type: "SHAPE"; data: { width: number; height: number } };
 export const RecursiveUnion = a.recursive<RecursiveUnion>(
+    "RecursiveUnion",
     (self) =>
         a.discriminator("type", {
             CHILD: a.object({ data: self }),
@@ -91,9 +92,6 @@ export const RecursiveUnion = a.recursive<RecursiveUnion>(
                 }),
             }),
         }),
-    {
-        id: "RecursiveUnion",
-    },
 );
 
 export const validationTestSuites: Record<
@@ -396,20 +394,15 @@ export const validationTestSuites: Record<
         ],
     },
     "object with nullable fields": {
-        schema: a.object(
-            {
-                id: a.nullable(a.string()),
-                createdAt: a.nullable(a.timestamp()),
-                count: a.nullable(a.number()),
-                isActive: a.nullable(a.boolean()),
-                tags: a.nullable(a.array(a.string())),
-                metadata: a.nullable(a.record(a.string())),
-                unknown: a.nullable(a.any()),
-            },
-            {
-                id: "logserializer",
-            },
-        ),
+        schema: a.object({
+            id: a.nullable(a.string()),
+            createdAt: a.nullable(a.timestamp()),
+            count: a.nullable(a.number()),
+            isActive: a.nullable(a.boolean()),
+            tags: a.nullable(a.array(a.string())),
+            metadata: a.nullable(a.record(a.string())),
+            unknown: a.nullable(a.any()),
+        }),
         goodInputs: [
             {
                 id: null,

--- a/tests/server/src/procedures/tests/sendObject.rpc.ts
+++ b/tests/server/src/procedures/tests/sendObject.rpc.ts
@@ -1,64 +1,59 @@
 import { defineRpc } from "arri";
 import { a } from "arri-validate";
 
-export const ObjectWithEveryType = a.object(
-    {
-        any: a.any(),
-        boolean: a.boolean(),
+export const ObjectWithEveryType = a.object("ObjectWithEveryType", {
+    any: a.any(),
+    boolean: a.boolean(),
+    string: a.string(),
+    timestamp: a.timestamp(),
+    float32: a.float32(),
+    float64: a.float64(),
+    int8: a.int8(),
+    uint8: a.uint8(),
+    int16: a.int16(),
+    uint16: a.uint16(),
+    int32: a.int32(),
+    uint32: a.uint32(),
+    int64: a.int64(),
+    uint64: a.uint64(),
+    enumerator: a.enumerator(["A", "B", "C"]),
+    array: a.array(a.boolean()),
+    object: a.object({
         string: a.string(),
+        boolean: a.boolean(),
         timestamp: a.timestamp(),
-        float32: a.float32(),
-        float64: a.float64(),
-        int8: a.int8(),
-        uint8: a.uint8(),
-        int16: a.int16(),
-        uint16: a.uint16(),
-        int32: a.int32(),
-        uint32: a.uint32(),
-        int64: a.int64(),
-        uint64: a.uint64(),
-        enumerator: a.enumerator(["A", "B", "C"]),
-        array: a.array(a.boolean()),
-        object: a.object({
-            string: a.string(),
-            boolean: a.boolean(),
-            timestamp: a.timestamp(),
+    }),
+    record: a.record(a.boolean()),
+    discriminator: a.discriminator("type", {
+        A: a.object({
+            title: a.string(),
         }),
-        record: a.record(a.boolean()),
-        discriminator: a.discriminator("type", {
-            A: a.object({
-                title: a.string(),
-            }),
-            B: a.object({
-                title: a.string(),
-                description: a.string(),
-            }),
+        B: a.object({
+            title: a.string(),
+            description: a.string(),
         }),
-        nestedObject: a.object({
+    }),
+    nestedObject: a.object({
+        id: a.string(),
+        timestamp: a.timestamp(),
+        data: a.object({
             id: a.string(),
             timestamp: a.timestamp(),
             data: a.object({
                 id: a.string(),
                 timestamp: a.timestamp(),
-                data: a.object({
-                    id: a.string(),
-                    timestamp: a.timestamp(),
-                }),
             }),
         }),
-        nestedArray: a.array(
-            a.array(
-                a.object({
-                    id: a.string(),
-                    timestamp: a.timestamp(),
-                }),
-            ),
+    }),
+    nestedArray: a.array(
+        a.array(
+            a.object({
+                id: a.string(),
+                timestamp: a.timestamp(),
+            }),
         ),
-    },
-    {
-        id: "ObjectWithEveryType",
-    },
-);
+    ),
+});
 
 export default defineRpc({
     params: ObjectWithEveryType,

--- a/tests/server/src/procedures/tests/sendObjectWithNullableFields.rpc.ts
+++ b/tests/server/src/procedures/tests/sendObjectWithNullableFields.rpc.ts
@@ -2,6 +2,7 @@ import { defineRpc } from "arri";
 import { a } from "arri-validate";
 
 export const ObjectWithEveryNullableType = a.object(
+    "ObjectWithEveryNullableType",
     {
         any: a.nullable(a.any()),
         boolean: a.nullable(a.boolean()),
@@ -70,9 +71,6 @@ export const ObjectWithEveryNullableType = a.object(
                 ),
             ),
         ),
-    },
-    {
-        id: "ObjectWithEveryNullableType",
     },
 );
 

--- a/tests/server/src/procedures/tests/sendRecursiveObject.rpc.ts
+++ b/tests/server/src/procedures/tests/sendRecursiveObject.rpc.ts
@@ -8,13 +8,13 @@ interface RecursiveObject {
 }
 
 const RecursiveObject = a.recursive<RecursiveObject>(
+    "RecursiveObject",
     (self) =>
         a.object({
             left: a.nullable(self),
             right: a.nullable(self),
             value: a.string(),
         }),
-    { id: "RecursiveObject" },
 );
 
 export default defineRpc({

--- a/tests/server/src/procedures/tests/sendRecursiveUnion.rpc.ts
+++ b/tests/server/src/procedures/tests/sendRecursiveUnion.rpc.ts
@@ -10,29 +10,25 @@ type RecursiveUnion =
     | { type: "TEXT"; data: string }
     | { type: "SHAPE"; data: { width: number; height: number; color: string } };
 
-const RecursiveUnion = a.recursive<RecursiveUnion>(
-    (self) =>
-        a.discriminator("type", {
-            CHILD: a.object({
-                data: self,
-            }),
-            CHILDREN: a.object({
-                data: a.array(self),
-            }),
-            TEXT: a.object({
-                data: a.string(),
-            }),
-            SHAPE: a.object({
-                data: a.object({
-                    width: a.float64(),
-                    height: a.float64(),
-                    color: a.string(),
-                }),
+const RecursiveUnion = a.recursive<RecursiveUnion>("RecursiveUnion", (self) =>
+    a.discriminator("type", {
+        CHILD: a.object({
+            data: self,
+        }),
+        CHILDREN: a.object({
+            data: a.array(self),
+        }),
+        TEXT: a.object({
+            data: a.string(),
+        }),
+        SHAPE: a.object({
+            data: a.object({
+                width: a.float64(),
+                height: a.float64(),
+                color: a.string(),
             }),
         }),
-    {
-        id: "RecursiveUnion",
-    },
+    }),
 );
 
 export default defineRpc({

--- a/tests/server/src/procedures/tests/streamAutoReconnect.rpc.ts
+++ b/tests/server/src/procedures/tests/streamAutoReconnect.rpc.ts
@@ -2,19 +2,13 @@ import { defineEventStreamRpc } from "arri";
 import { a } from "arri-validate";
 
 export default defineEventStreamRpc({
-    params: a.object(
-        {
-            messageCount: a.uint8(),
-        },
-        { id: "AutoReconnectParams" },
-    ),
-    response: a.object(
-        {
-            count: a.uint8(),
-            message: a.string(),
-        },
-        { id: "AutoReconnectResponse" },
-    ),
+    params: a.object("AutoReconnectParams", {
+        messageCount: a.uint8(),
+    }),
+    response: a.object("AutoReconnectResponse", {
+        count: a.uint8(),
+        message: a.string(),
+    }),
     handler({ params, stream }, event) {
         let messageCount = 0;
         const interval = setInterval(async () => {

--- a/tests/server/src/procedures/tests/streamConnectionErrorTest.rpc.ts
+++ b/tests/server/src/procedures/tests/streamConnectionErrorTest.rpc.ts
@@ -4,23 +4,13 @@ import { a } from "arri-validate";
 export default defineEventStreamRpc({
     description:
         "This route will always return an error. The client should automatically retry with exponential backoff.",
-    params: a.object(
-        {
-            statusCode: a.uint16(),
-            statusMessage: a.string(),
-        },
-        {
-            id: "StreamConnectionErrorTestParams",
-        },
-    ),
-    response: a.object(
-        {
-            message: a.string(),
-        },
-        {
-            id: "StreamConnectionErrorTestResponse",
-        },
-    ),
+    params: a.object("StreamConnectionErrorTestParams", {
+        statusCode: a.uint16(),
+        statusMessage: a.string(),
+    }),
+    response: a.object("StreamConnectionErrorTestResponse", {
+        message: a.string(),
+    }),
     async handler({ params }) {
         throw defineError(params.statusCode, {
             message: params.statusMessage,

--- a/tests/server/src/procedures/tests/streamLargeObjects.rpc.ts
+++ b/tests/server/src/procedures/tests/streamLargeObjects.rpc.ts
@@ -4,6 +4,7 @@ import { defineEventStreamRpc } from "arri";
 import { a } from "arri-validate";
 
 export const StreamLargeObjectsResponse = a.object(
+    "StreamLargeObjectsResponse",
     {
         numbers: a.array(a.number()),
         objects: a.array(
@@ -13,9 +14,6 @@ export const StreamLargeObjectsResponse = a.object(
                 email: a.string(),
             }),
         ),
-    },
-    {
-        id: "StreamLargeObjectsResponse",
     },
 );
 

--- a/tests/server/src/procedures/tests/streamMessages.rpc.ts
+++ b/tests/server/src/procedures/tests/streamMessages.rpc.ts
@@ -3,12 +3,9 @@ import { faker } from "@faker-js/faker";
 import { defineEventStreamRpc } from "arri";
 import { a } from "arri-validate";
 
-export const ChatMessageParams = a.object(
-    {
-        channelId: a.string(),
-    },
-    { id: "ChatMessageParams" },
-);
+export const ChatMessageParams = a.object("ChatMessageParams", {
+    channelId: a.string(),
+});
 
 const ChatMessageBase = a.object({
     id: a.string(),
@@ -17,30 +14,26 @@ const ChatMessageBase = a.object({
     date: a.timestamp(),
 });
 
-export const ChatMessage = a.discriminator(
-    "messageType",
-    {
-        TEXT: a.extend(
-            ChatMessageBase,
-            a.object({
-                text: a.string(),
-            }),
-        ),
-        IMAGE: a.extend(
-            ChatMessageBase,
-            a.object({
-                image: a.string(),
-            }),
-        ),
-        URL: a.extend(
-            ChatMessageBase,
-            a.object({
-                url: a.string(),
-            }),
-        ),
-    },
-    { id: "ChatMessage" },
-);
+export const ChatMessage = a.discriminator("ChatMessage", "messageType", {
+    TEXT: a.extend(
+        ChatMessageBase,
+        a.object({
+            text: a.string(),
+        }),
+    ),
+    IMAGE: a.extend(
+        ChatMessageBase,
+        a.object({
+            image: a.string(),
+        }),
+    ),
+    URL: a.extend(
+        ChatMessageBase,
+        a.object({
+            url: a.string(),
+        }),
+    ),
+});
 
 export type ChatMessage = a.infer<typeof ChatMessage>;
 

--- a/tests/server/src/routes/other.ts
+++ b/tests/server/src/routes/other.ts
@@ -3,14 +3,9 @@ import { a } from "arri-validate";
 
 const router = new ArriRouter();
 
-const DefaultPayload = a.object(
-    {
-        message: a.string(),
-    },
-    {
-        id: "DefaultPayload",
-    },
-);
+const DefaultPayload = a.object("DefaultPayload", {
+    message: a.string(),
+});
 
 router.route({
     path: "/routes/hello-world",


### PR DESCRIPTION
Allows you to specify object ids with a shorter syntax

Before
```ts
const MyObject = a.object(
  {
    a: a.string(),
    b: a.int32(),
    c: a.boolean(),
  }, 
  { id: "MyObject" });
```

After
```ts
const MyObject = a.object("MyObject", {
  a: a.string(),
  b: a.int32(),
  c: a.boolean(),
})
```