### PR TITLE
feature: add `arri use` and `arri list` commands

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@arrirpc/codegen-utils':
         specifier: workspace:*
         version: link:../codegen-utils
+      '@arrirpc/schema':
+        specifier: workspace:*
+        version: link:../schema
       '@joshmossas/listhen':
         specifier: ^1.10.1
         version: 1.10.1
@@ -325,9 +328,6 @@ importers:
       prettier:
         specifier: ^3.3.0
         version: 3.3.0
-      scule:
-        specifier: ^1.3.0
-        version: 1.3.0
     devDependencies:
       '@types/degit':
         specifier: ^2.8.6

--- a/tooling/cli/package.json
+++ b/tooling/cli/package.json
@@ -3,9 +3,16 @@
   "version": "0.48.2",
   "type": "module",
   "license": "MIT",
-  "author": { "name": "joshmossas", "url": "https://github.com/joshmossas" },
-  "bin": { "arri": "./dist/cli.mjs" },
-  "bugs": { "url": "https://github.com/modiimedia/arri/issues" },
+  "author": {
+    "name": "joshmossas",
+    "url": "https://github.com/joshmossas"
+  },
+  "bin": {
+    "arri": "./dist/cli.mjs"
+  },
+  "bugs": {
+    "url": "https://github.com/modiimedia/arri/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/modiimedia/arri.git",
@@ -14,12 +21,15 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@arrirpc/codegen-dart": "workspace:*",
     "@arrirpc/codegen-kotlin": "workspace:*",
     "@arrirpc/codegen-ts": "workspace:*",
     "@arrirpc/codegen-utils": "workspace:*",
+    "@arrirpc/schema": "workspace:*",
     "@joshmossas/listhen": "^1.10.1",
     "c12": "^1.10.0",
     "chokidar": "^3.6.0",
@@ -33,8 +43,9 @@
     "h3": "^1.11.1",
     "ofetch": "^1.3.4",
     "pathe": "^1.1.2",
-    "prettier": "^3.3.0",
-    "scule": "^1.3.0"
+    "prettier": "^3.3.0"
   },
-  "devDependencies": { "@types/degit": "^2.8.6" }
+  "devDependencies": {
+    "@types/degit": "^2.8.6"
+  }
 }

--- a/tooling/cli/src/_main.ts
+++ b/tooling/cli/src/_main.ts
@@ -5,6 +5,8 @@ import build from "./commands/build";
 import codegen from "./commands/codegen";
 import dev from "./commands/dev";
 import init from "./commands/init";
+import list from "./commands/list";
+import use from "./commands/use";
 import version from "./commands/version";
 
 const main = defineCommand({
@@ -13,6 +15,8 @@ const main = defineCommand({
         codegen,
         dev,
         init,
+        list,
+        use,
         version,
     },
 });

--- a/tooling/cli/src/commands/init.ts
+++ b/tooling/cli/src/commands/init.ts
@@ -1,11 +1,11 @@
 import fs, { readFileSync, rmSync, writeFileSync } from "node:fs";
 
+import { kebabCase } from "@arrirpc/codegen-utils";
 import { defineCommand } from "citty";
 import Degit from "degit";
 import enquirer from "enquirer";
 import path from "pathe";
 import prettier from "prettier";
-import { kebabCase } from "scule";
 
 import { logger } from "../common";
 

--- a/tooling/cli/src/commands/list.ts
+++ b/tooling/cli/src/commands/list.ts
@@ -1,0 +1,40 @@
+import { defineCommand } from "citty";
+
+import { getArriPackageMetadata, logger } from "../common";
+
+export default defineCommand({
+    meta: {
+        name: "List",
+        description: "List the available arri versions",
+    },
+    args: {
+        tags: {
+            type: "boolean",
+            default: false,
+            description: "List available tags",
+        },
+    },
+    async run({ args }) {
+        const arriInfo = await getArriPackageMetadata();
+        if (args.tags) {
+            const output = Object.keys(arriInfo["dist-tags"]).map(
+                (tag) => `- ${tag} (${arriInfo["dist-tags"][tag]})`,
+            );
+            logger.log(output.join("\n"));
+            return;
+        }
+        const tagMap: Record<string, string> = {};
+        for (const key of Object.keys(arriInfo["dist-tags"])) {
+            const version = arriInfo["dist-tags"][key]!;
+            tagMap[version] = key;
+        }
+        const output = Object.keys(arriInfo.versions).map((version) => {
+            const tag = tagMap[version];
+            if (tag) {
+                return `- ${version} (${tag})`;
+            }
+            return `- ${version}`;
+        });
+        logger.log(output.join("\n"));
+    },
+});

--- a/tooling/cli/src/commands/use.test.ts
+++ b/tooling/cli/src/commands/use.test.ts
@@ -1,0 +1,67 @@
+import { updatePackageJson, updatePubspecYaml } from "./use";
+
+describe("updatePackageJson()", () => {
+    it("updates relevant lines and preserves formatting", () => {
+        const input = `{
+    "dependencies": {
+        "arri": "^0.1.1",
+        "@arrirpc/client": "^0.1.1",
+        "express": "^1.0.0"
+    },
+    "devDependencies": {
+        "@arrirpc/eslint-plugin": "^0.1.1"
+    }
+}`;
+        const expectedOutput = `{
+    "dependencies": {
+        "arri": "^2.0.0",
+        "@arrirpc/client": "^2.0.0",
+        "express": "^1.0.0"
+    },
+    "devDependencies": {
+        "@arrirpc/eslint-plugin": "^2.0.0"
+    }
+}`;
+        const output = updatePackageJson(input, "2.0.0");
+        expect(output).toBe(expectedOutput);
+    });
+    it("updates relevant lines and preserves jsonc comments", () => {
+        const input = `{
+    "dependencies": {
+        "arri": "^0.1.1", // this is a comment
+        "express": "^1.0.0",
+        "@arrirpc/server": "^0.1.1",
+    },
+    "devDependencies": {
+        "@arrirpc/eslint-plugin": "^0.1.1", // this is "another comment"
+    },
+}`;
+        const expectedOutput = `{
+    "dependencies": {
+        "arri": "^2.0.0", // this is a comment
+        "express": "^1.0.0",
+        "@arrirpc/server": "^2.0.0",
+    },
+    "devDependencies": {
+        "@arrirpc/eslint-plugin": "^2.0.0", // this is "another comment"
+    },
+}`;
+        const output = updatePackageJson(input, "2.0.0");
+        expect(output).toBe(expectedOutput);
+    });
+});
+
+describe("updatePubspecYaml()", () => {
+    it("updates relevant lines while preserving formatting and comments", () => {
+        const input = `dependencies:
+    arri_client: 0.1.0 # this is a comment
+    http: 1.0.1
+    # this is another comment`;
+        const expectedOutput = `dependencies:
+    arri_client: ^2.0.0 # this is a comment
+    http: 1.0.1
+    # this is another comment`;
+        const output = updatePubspecYaml(input, "2.0.0");
+        expect(output).toBe(expectedOutput);
+    });
+});

--- a/tooling/cli/src/commands/use.ts
+++ b/tooling/cli/src/commands/use.ts
@@ -1,0 +1,183 @@
+import { a } from "@arrirpc/schema";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { readFile, writeFile } from "fs/promises";
+import { ofetch } from "ofetch";
+import path from "pathe";
+
+import { getArriPackageMetadata } from "../common";
+
+export default defineCommand({
+    meta: {
+        name: "use",
+        description: "Use a specific arri version",
+    },
+    args: {
+        version: {
+            type: "positional",
+            required: true,
+            description:
+                'The version you want to use. You can also specify a tag such as "latest".',
+        },
+    },
+    async run({ args }) {
+        const arriInfo = await getArriPackageMetadata();
+        const version = arriInfo["dist-tags"][args.version] ?? args.version;
+        if (!arriInfo.versions[version]) {
+            throw new Error(
+                `Version ${args.version} doesn't exist. Run "arri list" to see available versions.`,
+            );
+        }
+        const globby = (await import("globby")).globby;
+        // UPDATE TS DEPENDENCIES
+        consola.info(`Checking for TS/JS dependencies`);
+        const fileMap: Record<string, string> = {};
+
+        const pkgJsonFiles = await globby(
+            [
+                "package.json",
+                "**/package.json",
+                "package.jsonc",
+                "**/package.jsonc",
+            ],
+            {
+                ignore: ["node_modules", "**/node_modules", "**/dist", "dist"],
+            },
+        );
+        const jkgJsonFileTasks: Promise<any>[] = [];
+        for (const file of pkgJsonFiles) {
+            jkgJsonFileTasks.push(
+                readFile(path.resolve(file), "utf8").then((content) => {
+                    fileMap[file] = updatePackageJson(content, version);
+                }),
+            );
+        }
+
+        await Promise.all(jkgJsonFileTasks);
+
+        // UPDATE DART DEPENDENCIES
+        consola.info(`Checking for dart dependencies`);
+        const pubspecFiles = await globby(["pubspec.yaml", "**/pubspec.yaml"]);
+        const pubspecFileTasks: Promise<any>[] = [];
+        if (pubspecFiles.length) {
+            const dartPackage = await getDartPackageMeta();
+            let hasVersion = false;
+            for (const item of dartPackage.versions) {
+                if (item.version == version) {
+                    hasVersion = true;
+                    break;
+                }
+            }
+            if (!hasVersion) {
+                throw new Error(
+                    `Version ${version} does not have Dart support`,
+                );
+            }
+        }
+        for (const file of pubspecFiles) {
+            pubspecFileTasks.push(
+                readFile(path.resolve(file), "utf8").then((content) => {
+                    fileMap[file] = updatePubspecYaml(content, version);
+                }),
+            );
+        }
+        await Promise.all(pubspecFileTasks);
+
+        const updateTasks: Promise<any>[] = [];
+        for (const key of Object.keys(fileMap)) {
+            updateTasks.push(
+                writeFile(path.resolve(key), fileMap[key]!, "utf8").then(() =>
+                    consola.success(`Updated ${key}`),
+                ),
+            );
+        }
+        await Promise.all(updateTasks);
+        consola.success(
+            `Updated to ${version}. Rerun your install commands to update your dependencies.`,
+        );
+    },
+});
+
+export function updatePackageJson(
+    fileContent: string,
+    targetVersion: string,
+): string {
+    const lines = fileContent.split("\n");
+    const output: string[] = [];
+    for (const line of lines) {
+        if (line.includes(`"arri"`)) {
+            output.push(updateLine(line));
+            continue;
+        }
+        if (line.includes(`"@arrirpc/`)) {
+            output.push(updateLine(line));
+            continue;
+        }
+        output.push(line);
+    }
+    function updateLine(line: string) {
+        const parts = line.split('":');
+        if (parts.length < 2) {
+            return line;
+        }
+        const targetParts = parts[1]!.split('"');
+        targetParts[1] = `^${targetVersion}`;
+        parts[1] = targetParts.join('"');
+        return parts.join('":');
+    }
+    return output.join("\n");
+}
+
+const PubPackageResponse = a.object({
+    name: a.string(),
+    versions: a.array(
+        a.object({
+            version: a.string(),
+            pubspec: a.object({
+                name: a.string(),
+                description: a.string(),
+                version: a.string(),
+                repository: a.string(),
+                environment: a.object({
+                    sdk: a.string(),
+                }),
+                dependencies: a.record(a.string()),
+                dev_dependencies: a.record(a.string()),
+            }),
+            archive_url: a.string(),
+            archive_sha256: a.string(),
+            published: a.string(),
+        }),
+    ),
+});
+
+export async function getDartPackageMeta() {
+    const response = await ofetch("https://pub.dev/api/packages/arri_client");
+    const data = a.parse(PubPackageResponse, response);
+    return data;
+}
+
+export function updatePubspecYaml(
+    fileContent: string,
+    version: string,
+): string {
+    const lines = fileContent.split("\n");
+    const output: string[] = [];
+    for (const line of lines) {
+        if (line.includes("arri_client: ")) {
+            const parts = line.split(": ");
+            if (parts.length < 2) {
+                output.push(line);
+                continue;
+            }
+            const targetPart = parts[1];
+            const subParts = targetPart!.split(" ");
+            subParts[0] = `^${version}`;
+            parts[1] = subParts.join(" ");
+            output.push(parts.join(": "));
+            continue;
+        }
+        output.push(line);
+    }
+    return output.join("\n");
+}

--- a/tooling/cli/src/common.ts
+++ b/tooling/cli/src/common.ts
@@ -1,12 +1,17 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 
-import { removeDisallowedChars } from "@arrirpc/codegen-utils";
+import {
+    camelCase,
+    kebabCase,
+    removeDisallowedChars,
+} from "@arrirpc/codegen-utils";
+import { a, ValidationError } from "@arrirpc/schema";
 import { createConsola } from "consola";
 import { type globby } from "globby";
+import { ofetch } from "ofetch";
 import path from "pathe";
 import prettier from "prettier";
-import { camelCase, kebabCase } from "scule";
 
 import { type ResolvedArriConfig } from "./config";
 
@@ -187,3 +192,87 @@ export function isInsideDir(dir: string, parentDir: string) {
     }
     return false;
 }
+
+export async function getArriPackageMetadata() {
+    const npmPackageResponse = await ofetch("https://registry.npmjs.com/arri");
+    const arriInfo = a.safeParse(NpmRegistryPackage, npmPackageResponse);
+    if (!arriInfo.success) {
+        const errors = a.errors(NpmRegistryPackage, npmPackageResponse);
+        console.warn(errors);
+        throw new ValidationError({
+            message: "Arri parsing response from registry",
+            errors,
+        });
+    }
+    return arriInfo.value;
+}
+const NpmPackageVersion = a.partial(
+    a.object({
+        name: a.string(),
+        version: a.string(),
+        _id: a.string(),
+        maintainers: a.array(
+            a.object({
+                name: a.string(),
+                email: a.string(),
+            }),
+        ),
+        bin: a.record(a.string()),
+        dist: a.any(),
+        main: a.string(),
+        type: a.string(),
+        types: a.string(),
+        module: a.string(),
+        gitHead: a.string(),
+        _npmUser: a.object({
+            name: a.string(),
+            email: a.string(),
+        }),
+        description: a.string(),
+        directories: a.record(a.any()),
+        _nodeVersion: a.string(),
+        dependencies: a.record(a.string()),
+        _hasShrinkWrap: a.boolean(),
+        _npmOperationalInternal: a.any(),
+    }),
+);
+
+const NpmRegistryPackage = a.object({
+    _id: a.string(),
+    _rev: a.string(),
+    name: a.string(),
+    description: a.string(),
+    "dist-tags": a.record(a.string()),
+    versions: a.record(NpmPackageVersion),
+    time: a.record(a.string()),
+    maintainers: a.array(
+        a.object({
+            name: a.string(),
+            email: a.string(),
+        }),
+    ),
+    author: a.object({
+        name: a.string(),
+        url: a.string(),
+    }),
+    repository: a.optional(
+        a.partial(
+            a.object({
+                type: a.string(),
+                url: a.string(),
+                directory: a.string(),
+            }),
+        ),
+    ),
+    license: a.optional(a.string()),
+    homepage: a.optional(a.string()),
+    bugs: a.optional(
+        a.partial(
+            a.object({
+                url: a.string(),
+            }),
+        ),
+    ),
+    readme: a.optional(a.string()),
+    readmeFilename: a.optional(a.string()),
+});


### PR DESCRIPTION
- `arri use <version>` will find nested package.json and pubspec.yaml files and update them to the specified arri dependency version
- `arri list` will list available arri versions