### PR TITLE
fix: naming of packages in install instructions

### DIFF
--- a/languages/ts/ts-server/README.md
+++ b/languages/ts/ts-server/README.md
@@ -45,10 +45,10 @@ pnpm run dev
 
 ```bash
 # npm
-npm install arri @arri/server @arri/schema
+npm install arri @arrirpc/server @arrirpc/schema
 
 # pnpm
-pnpm install arri @arri/server @arri/schema
+pnpm install arri @arrirpc/server @arrirpc/schema
 ```
 
 ### Scaffold Your Project


### PR DESCRIPTION
Hi Josh,

during manual installation (`npm install arri @arri/server @arri/schema`), npm gave me this error:
```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@arri%2fschema - Not found
npm error 404
npm error 404  '@arri/schema@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
```

I think the packages in the docs are misspelled, aren't they?

BR David