### PR TITLE
bugfix: fix broken swift builds on macOS

### DIFF
--- a/languages/rust/rust-client/project.json
+++ b/languages/rust/rust-client/project.json
@@ -40,6 +40,7 @@
         "{projectRoot}/Cargo.lock"
       ],
       "outputs": ["{projectRoot}/target"],
+      "cache": false,
       "options": {
         "command": "cargo build",
         "cwd": "languages/rust/rust-client"

--- a/languages/swift/swift-client/Package.swift
+++ b/languages/swift/swift-client/Package.swift
@@ -5,6 +5,14 @@ import PackageDescription
 
 let package = Package(
     name: "ArriClient",
+    // platforms: [
+    //     .iOS("13.0"),
+    //     .macCatalyst("13.0"),
+    //     .macOS("10.15"),
+    //     .tvOS("13.0"),
+    //     .visionOS("1.0"),
+    //     .watchOS("6.0")
+    // ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/languages/swift/swift-client/Sources/ArriClient/ArriClient.swift
+++ b/languages/swift/swift-client/Sources/ArriClient/ArriClient.swift
@@ -10,6 +10,7 @@ import NIOFoundationCompat
 let jsonEncoder = JSONEncoder()
 let jsonDecoder = JSONDecoder()
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public func parsedArriHttpRequest<TParams: ArriClientModel, TResponse: ArriClientModel>(
     delegate: ArriRequestDelegate,
     url: String,
@@ -238,12 +239,12 @@ public func serializeAny(input: JSON) -> String {
 
 
 //// Request Delegate ////
-
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public protocol ArriRequestDelegate {
     func handleHTTPRequest(request: ArriHTTPRequest) async throws -> ArriHTTPResponse<Data>
     func handleHTTPEventStreamRequest(request: ArriHTTPRequest) async throws -> ArriSSEResponse
 }
-
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public struct DefaultRequestDelegate: ArriRequestDelegate {
     var maxBodyBytes: Int = 1024 * 1024
     public init() {}
@@ -307,6 +308,7 @@ public struct DefaultRequestDelegate: ArriRequestDelegate {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public enum ArriSSEResponse {
     case ok(ArriHTTPResponse<HTTPClientResponse.Body>)
     case error(ArriHTTPResponse<Data>)
@@ -386,6 +388,7 @@ public enum ArriResponseErrors: Error {
 }
 
 extension URLSession {
+    @available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
     func asyncData(with: URLRequest) async throws -> (Data?, HTTPURLResponse) {
         return try await withCheckedThrowingContinuation { continuation in
             URLSession.shared.dataTask(with: with) {data, response, error in 
@@ -596,10 +599,12 @@ public func sseEventListFromString(input: String, debug: Bool) -> ([RawSSEEvent]
     return (events, String(leftover))
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public protocol ArriCancellable {
     mutating func cancel() -> ()
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public struct EventSourceOptions<T: ArriClientModel> {
     public var onMessage: (T, inout EventSource<T>) -> ()
     public var onRequest: ((ArriHTTPRequest, inout EventSource<T>) -> ()) = { _, __ in }
@@ -666,6 +671,7 @@ public struct EventSourceOptions<T: ArriClientModel> {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public struct EventSource<T: ArriClientModel>: ArriCancellable {
     var url: String
     var method: String
@@ -701,6 +707,7 @@ public struct EventSource<T: ArriClientModel>: ArriCancellable {
         self.cancelled = true
     }
 
+    @available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
     public mutating func sendRequest() async {
         var urlComponents = URLComponents(string: self.url)
         if urlComponents == nil {

--- a/languages/swift/swift-codegen-reference/Sources/SwiftCodegenReference/SwiftCodegenReference.swift
+++ b/languages/swift/swift-codegen-reference/Sources/SwiftCodegenReference/SwiftCodegenReference.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ArriClient
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public class ExampleClient {
     let baseURL: String
     let delegate: ArriRequestDelegate
@@ -35,6 +36,7 @@ public class ExampleClient {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public class ExampleClientBooksService {
     let baseURL: String
     let delegate: ArriRequestDelegate

--- a/languages/swift/swift-codegen-reference/Sources/SwiftCodegenReferenceMain/Client.swift
+++ b/languages/swift/swift-codegen-reference/Sources/SwiftCodegenReferenceMain/Client.swift
@@ -6,6 +6,7 @@ import NIOCore
 import NIOFoundationCompat
 import SwiftCodegenReference
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 struct CustomRequestDelegate: ArriRequestDelegate {
 
 

--- a/languages/swift/swift-codegen-reference/Sources/SwiftCodegenReferenceMain/Main.swift
+++ b/languages/swift/swift-codegen-reference/Sources/SwiftCodegenReferenceMain/Main.swift
@@ -3,6 +3,7 @@ import ArriClient
 import SwiftCodegenReference
 
 @main
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 struct Main {
     static func main() async throws {
         let client = ExampleClient(

--- a/languages/swift/swift-codegen/src/procedures.ts
+++ b/languages/swift/swift-codegen/src/procedures.ts
@@ -170,7 +170,8 @@ export function swiftServiceFromSchema(
             continue;
         }
     }
-    return `public class ${serviceName} {
+    return `@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
+public class ${serviceName} {
     let baseURL: String
     let delegate: ArriRequestDelegate
     let headers: () -> Dictionary<String, String>

--- a/tests/clients/swift/Sources/TestClient.g.swift
+++ b/tests/clients/swift/Sources/TestClient.g.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ArriClient
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public class TestClient {
     let baseURL: String
     let delegate: ArriRequestDelegate
@@ -30,6 +31,7 @@ public class TestClient {
         
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public class TestClientTestsService {
     let baseURL: String
     let delegate: ArriRequestDelegate
@@ -271,6 +273,7 @@ public class TestClientTestsService {
 }
 
 
+@available(macOS 10.15, iOS 13, tvOS 13, visionOS 1, macCatalyst 13, *)
 public class TestClientUsersService {
     let baseURL: String
     let delegate: ArriRequestDelegate


### PR DESCRIPTION
Add `@available` tags to specify minimum deployment version for iOS, macOS, etc