### PR TITLE
feature: json schema support date time string

### DIFF
--- a/tooling/json-schema-to-jtd/package.json
+++ b/tooling/json-schema-to-jtd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-to-jtd",
-  "version": "0.69.2",
+  "version": "0.69.3-beta.1",
   "license": "MIT",
   "author": {
     "name": "joshmossas",

--- a/tooling/json-schema-to-jtd/src/index.test.ts
+++ b/tooling/json-schema-to-jtd/src/index.test.ts
@@ -40,6 +40,19 @@ it("Converts strings", () => {
     expect(jsonSchemaToJtdSchema(input)).toStrictEqual(expectedOutput);
 });
 
+it('Converts strings that are marked as format "date-time"', () => {
+    const input: JsonSchemaScalarType = {
+        type: "string",
+        format: "date-time",
+    };
+    const expectedOutput: SchemaFormType = {
+        type: "timestamp",
+        metadata: emptyMetadata,
+        nullable: undefined,
+    };
+    expect(jsonSchemaToJtdSchema(input)).toStrictEqual(expectedOutput);
+});
+
 it("Converts objects", () => {
     const input: JsonSchemaObject = {
         type: "object",

--- a/tooling/json-schema-to-jtd/src/index.test.ts
+++ b/tooling/json-schema-to-jtd/src/index.test.ts
@@ -51,6 +51,17 @@ it('Converts strings that are marked as format "date-time"', () => {
         nullable: undefined,
     };
     expect(jsonSchemaToJtdSchema(input)).toStrictEqual(expectedOutput);
+    const input2: JsonSchemaScalarType = {
+        type: "string",
+        format: "date-time",
+        nullable: true,
+    };
+    const expectedOutput2: SchemaFormType = {
+        type: "timestamp",
+        metadata: emptyMetadata,
+        nullable: true,
+    };
+    expect(jsonSchemaToJtdSchema(input2)).toStrictEqual(expectedOutput2);
 });
 
 it("Converts objects", () => {

--- a/tooling/json-schema-to-jtd/src/index.ts
+++ b/tooling/json-schema-to-jtd/src/index.ts
@@ -125,6 +125,13 @@ export function jsonSchemaScalarToJtdScalar(
                 metadata: meta,
             };
         case "string":
+            if (input.format === "date-time") {
+                return {
+                    type: "timestamp",
+                    nullable: input.nullable,
+                    metadata: meta,
+                };
+            }
             return {
                 type: "string",
                 nullable: input.nullable,

--- a/tooling/json-schema-to-jtd/src/models.ts
+++ b/tooling/json-schema-to-jtd/src/models.ts
@@ -29,6 +29,7 @@ export interface JsonSchemaTypeBase {
     title?: string;
     description?: string;
     nullable?: boolean;
+    format?: string;
 }
 
 export interface JsonSchemaScalarType extends JsonSchemaTypeBase {


### PR DESCRIPTION
Adds support for 
```json
{
  "type": "string",
  "format": "date-time"
}
```