### PR TITLE
Updated 'arri use' command to be stricter on versions.

### DIFF
--- a/tooling/cli/src/commands/use.test.ts
+++ b/tooling/cli/src/commands/use.test.ts
@@ -99,7 +99,7 @@ describe('updatePubspecYaml()', () => {
         expect(output.updated).toBe(true);
     });
 
-    it('updates relevant lines without preserving strict version numbers', () => {
+    it('updates relevant lines without implementing strict version numbers', () => {
         const input = `dependencies:
     arri_client: ^0.1.0 # this is a comment
     http: 1.0.1

--- a/tooling/cli/src/commands/use.test.ts
+++ b/tooling/cli/src/commands/use.test.ts
@@ -19,12 +19,12 @@ describe('updatePackageJson()', () => {
 }`;
         const expectedOutput = `{
     "dependencies": {
-        "arri": "^2.0.0",
-        "@arrirpc/client": "^2.0.0",
+        "arri": "2.0.0",
+        "@arrirpc/client": "2.0.0",
         "express": "^1.0.0"
     },
     "devDependencies": {
-        "@arrirpc/eslint-plugin": "^2.0.0"
+        "@arrirpc/eslint-plugin": "2.0.0"
     }
 }`;
         const output = updatePackageJson(input, '2.0.0');
@@ -44,15 +44,41 @@ describe('updatePackageJson()', () => {
 }`;
         const expectedOutput = `{
     "dependencies": {
-        "arri": "^2.0.0", // this is a comment
+        "arri": "2.0.0", // this is a comment
         "express": "^1.0.0",
-        "@arrirpc/server": "^2.0.0",
+        "@arrirpc/server": "2.0.0",
     },
     "devDependencies": {
-        "@arrirpc/eslint-plugin": "^2.0.0", // this is "another comment"
+        "@arrirpc/eslint-plugin": "2.0.0", // this is "another comment"
     },
 }`;
         const output = updatePackageJson(input, '2.0.0');
+        expect(output.content).toBe(expectedOutput);
+        expect(output.updated).toBe(true);
+    });
+
+    it('updates relevant lines without implementing strict versions', () => {
+        const input = `{
+            "dependencies": {
+                "arri": "^0.1.1", // this is a comment
+                "express": "^1.0.0",
+                "@arrirpc/server": "^0.1.1",
+            },
+            "devDependencies": {
+                "@arrirpc/eslint-plugin": "^0.1.1", // this is "another comment"
+            },
+        }`;
+        const expectedOutput = `{
+            "dependencies": {
+                "arri": "^3.0.0", // this is a comment
+                "express": "^1.0.0",
+                "@arrirpc/server": "^3.0.0",
+            },
+            "devDependencies": {
+                "@arrirpc/eslint-plugin": "^3.0.0", // this is "another comment"
+            },
+        }`;
+        const output = updatePackageJson(input, '3.0.0', false);
         expect(output.content).toBe(expectedOutput);
         expect(output.updated).toBe(true);
     });
@@ -65,10 +91,24 @@ describe('updatePubspecYaml()', () => {
     http: 1.0.1
     # this is another comment`;
         const expectedOutput = `dependencies:
-    arri_client: ^2.0.0 # this is a comment
+    arri_client: 2.0.0 # this is a comment
     http: 1.0.1
     # this is another comment`;
         const output = updatePubspecYaml(input, '2.0.0');
+        expect(output.content).toBe(expectedOutput);
+        expect(output.updated).toBe(true);
+    });
+
+    it('updates relevant lines without preserving strict version numbers', () => {
+        const input = `dependencies:
+    arri_client: ^0.1.0 # this is a comment
+    http: 1.0.1
+    # this is another comment`;
+        const expectedOutput = `dependencies:
+    arri_client: ^3.0.0 # this is a comment
+    http: 1.0.1
+    # this is another comment`;
+        const output = updatePubspecYaml(input, '3.0.0', false);
         expect(output.content).toBe(expectedOutput);
         expect(output.updated).toBe(true);
     });

--- a/tooling/cli/src/commands/use.ts
+++ b/tooling/cli/src/commands/use.ts
@@ -145,6 +145,7 @@ export default defineCommand({
 export function updatePackageJson(
     fileContent: string,
     targetVersion: string,
+    strict: boolean = true,
 ): { updated: boolean; content: string } {
     const lines = fileContent.split('\n');
     const output: string[] = [];
@@ -168,7 +169,7 @@ export function updatePackageJson(
             return line;
         }
         const targetParts = parts[1]!.split('"');
-        targetParts[1] = `^${targetVersion}`;
+        targetParts[1] = strict ? `${targetVersion}` : `^${targetVersion}`;
         parts[1] = targetParts.join('"');
         return parts.join('":');
     }
@@ -210,6 +211,7 @@ export async function getDartPackageMeta() {
 export function updatePubspecYaml(
     fileContent: string,
     version: string,
+    strict: boolean = true,
 ): {
     updated: boolean;
     content: string;
@@ -226,7 +228,7 @@ export function updatePubspecYaml(
             }
             const targetPart = parts[1];
             const subParts = targetPart!.split(' ');
-            subParts[0] = `^${version}`;
+            subParts[0] = strict ? `${version}` : `^${version}`;
             parts[1] = subParts.join(' ');
             output.push(parts.join(': '));
             updated = true;


### PR DESCRIPTION
Original issue: https://github.com/modiimedia/arri/issues/123

added simple `strict: boolean` parameter to `updatePackageJson` and `updatePubspecYaml` which is defaulted to `true`. 

Updated unit tests, and added 2 new ones for when `false` is passed to the `updatePackageJson` or `updatePubspecYaml`.

Forces strict version requirements in `pubspec.yaml`, and `package.json` for arri* dependencies.

(Haven't raised a PR before, so lemme know if I needed anything else here)