### PR TITLE
[ts-schema] feature: ensure that `a.optional` makes object keys optional + add `a.undefinable` schema which mimicks old behavior of `a.optional()`

### DIFF
--- a/languages/ts/ts-schema-typebox-adapter/src/index.ts
+++ b/languages/ts/ts-schema-typebox-adapter/src/index.ts
@@ -34,7 +34,7 @@ export function typeboxAdapter<TInput extends CleanedTSchema>(
         CleanedStatic<TInput>
     >[typeof VALIDATOR_KEY] = {
         output: {} as any as CleanedStatic<TInput>,
-        optional: (input as any)[OptionalKind] === 'Optional',
+        optional: ((input as any)[OptionalKind] === 'Optional') as false,
         parse(val: unknown, context) {
             if (typeof val === 'string') {
                 const parsedVal = JSON.parse(val);

--- a/languages/ts/ts-schema/src/adapters.ts
+++ b/languages/ts/ts-schema/src/adapters.ts
@@ -33,7 +33,7 @@ export function createStandardSchemaProperty<T>(
 /**
  * Ensure that non ATD compliant properties get hidden when serialized to JSON
  */
-export function hideInvalidProperties(schema: ASchema) {
+export function hideInvalidProperties(schema: ASchema<any, any>) {
     Object.defineProperty(schema, '~standard', { enumerable: false });
 }
 

--- a/languages/ts/ts-schema/src/compile.ts
+++ b/languages/ts/ts-schema/src/compile.ts
@@ -31,6 +31,7 @@ import {
     newValidationContext,
     SchemaValidator,
     ValidationContext,
+    VALIDATOR_KEY,
 } from './schemas';
 
 export {
@@ -243,7 +244,8 @@ export function compile<
 }
 
 type CompiledParser<TSchema extends ASchema<any>> = SchemaValidator<
-    InferType<TSchema>
+    InferType<TSchema>,
+    TSchema[typeof VALIDATOR_KEY]['optional'] | false
 >['parse'];
 
 export function getCompiledParser<TSchema extends ASchema<any>>(

--- a/languages/ts/ts-schema/src/lib/_namespace.ts
+++ b/languages/ts/ts-schema/src/lib/_namespace.ts
@@ -9,7 +9,7 @@ export { array } from './array';
 export { boolean } from './boolean';
 export { discriminator } from './discriminator';
 export { enumerator, stringEnum } from './enum';
-export { clone, nullable, optional } from './modifiers';
+export { clone, nullable, optional, undefinable } from './modifiers';
 export {
     float32,
     float64,

--- a/languages/ts/ts-schema/src/lib/any.ts
+++ b/languages/ts/ts-schema/src/lib/any.ts
@@ -28,8 +28,9 @@ export function any(options: ASchemaOptions = {}): ASchemaWithAdapters<any> {
         }
         return input;
     };
-    const validator: SchemaValidator<any> = {
+    const validator: SchemaValidator<any, false> = {
         output: undefined as any,
+        optional: false,
         parse: parse,
         coerce: (input, context) => {
             if (

--- a/languages/ts/ts-schema/src/lib/array.ts
+++ b/languages/ts/ts-schema/src/lib/array.ts
@@ -28,8 +28,12 @@ export function array<TInnerSchema extends ASchema<any> = any>(
     ): InferType<AArraySchema<TInnerSchema>> | undefined => {
         return parse(schema, input, context, false);
     };
-    const validator: SchemaValidator<InferType<AArraySchema<TInnerSchema>>> = {
+    const validator: SchemaValidator<
+        InferType<AArraySchema<TInnerSchema>>,
+        false
+    > = {
         output: [] as any,
+        optional: false,
         parse: parseType,
         coerce(input, context) {
             return parse(schema, input, context, true);

--- a/languages/ts/ts-schema/src/lib/boolean.ts
+++ b/languages/ts/ts-schema/src/lib/boolean.ts
@@ -21,6 +21,7 @@ export function boolean(
 ): AScalarSchemaWithAdapters<'boolean', boolean> {
     const validator: SchemaValidator<boolean> = {
         output: false,
+        optional: false,
         parse: parse,
         validate,
         serialize: serialize,

--- a/languages/ts/ts-schema/src/lib/discriminator.ts
+++ b/languages/ts/ts-schema/src/lib/discriminator.ts
@@ -124,9 +124,11 @@ export function discriminator<
             TDiscriminatorKey,
             TMapping,
             JoinedDiscriminator<TDiscriminatorKey, TMapping>
-        >
+        >,
+        false
     > = {
         output: {} as any,
+        optional: false,
         validate: isType,
         parse: parseType,
         coerce: (input, context) => {

--- a/languages/ts/ts-schema/src/lib/enum.ts
+++ b/languages/ts/ts-schema/src/lib/enum.ts
@@ -81,6 +81,7 @@ export function enumerator<TKeys extends string, TValues extends TKeys[]>(
     };
     const validator: SchemaValidator<TKeys> = {
         output: paramA[0] ?? ('' as any),
+        optional: false,
         parse: parse,
         coerce: (input, context) => {
             if (isType(input)) {

--- a/languages/ts/ts-schema/src/lib/modifiers.test.ts
+++ b/languages/ts/ts-schema/src/lib/modifiers.test.ts
@@ -179,7 +179,6 @@ describe('optional()', () => {
             assertType<Schema1>({
                 id: '',
                 name: 'john',
-                tags: undefined,
             });
         });
     });

--- a/languages/ts/ts-schema/src/lib/numbers.ts
+++ b/languages/ts/ts-schema/src/lib/numbers.ts
@@ -200,6 +200,7 @@ export function int64(
     }
     const validator: SchemaValidator<bigint> = {
         output: BigInt('0'),
+        optional: false,
         validate: isType,
         parse: parse,
         coerce: parse,
@@ -271,6 +272,7 @@ export function uint64(
     }
     const validator: SchemaValidator<bigint> = {
         output: BigInt('0'),
+        optional: false,
         validate: isType,
         parse: parse,
         coerce: parse,
@@ -371,6 +373,7 @@ function numberScalarType<TType extends NumberType>(
     };
     const validator: SchemaValidator<number> = {
         output: 0,
+        optional: false,
         validate,
         parse: parse,
         serialize: serializeNumber,

--- a/languages/ts/ts-schema/src/lib/object.ts
+++ b/languages/ts/ts-schema/src/lib/object.ts
@@ -31,14 +31,14 @@ import { optional } from './modifiers';
  * a.validate(Schema, {foo: null, bar: 0}) // false
  */
 export function object<
-    TInput extends Record<any, ASchema> = any,
+    TInput extends Record<any, ASchema<any, any>> = any,
     TAdditionalProps extends boolean = false,
 >(
     input: TInput,
     opts?: AObjectSchemaOptions<TAdditionalProps>,
 ): AObjectSchemaWithAdapters<InferObjectOutput<TInput>, TAdditionalProps>;
 export function object<
-    TInput extends Record<any, ASchema> = any,
+    TInput extends Record<any, ASchema<any, any>> = any,
     TAdditionalProps extends boolean = false,
 >(
     id: string,
@@ -46,7 +46,7 @@ export function object<
 ): AObjectSchemaWithAdapters<InferObjectOutput<TInput>, TAdditionalProps>;
 export function object<
     // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-    TInput extends Record<any, ASchema> = {},
+    TInput extends Record<any, ASchema<any, any>> = {},
     TAdditionalProps extends boolean = false,
 >(
     propA: TInput | string,
@@ -90,6 +90,7 @@ export function object<
     };
     const validator: SchemaValidator<any> = {
         output: {} as any satisfies InferObjectOutput<TInput>,
+        optional: false,
         parse: decode,
         coerce(input: unknown, context) {
             return decodeObjectSchema(
@@ -531,6 +532,7 @@ export function extend<
         validateObjectSchema(schema as any, input);
     const validator: ASchema[typeof VALIDATOR_KEY] = {
         output: {},
+        optional: false,
         parse(input: unknown, context: ValidationContext) {
             return decodeObjectSchema(schema as any, input, context, false);
         },

--- a/languages/ts/ts-schema/src/lib/record.ts
+++ b/languages/ts/ts-schema/src/lib/record.ts
@@ -31,7 +31,7 @@ import { serializeString } from './string';
  * )
  * a.validate(ObjectRecord, {foo: {id: "1", date: new Date()}}) // true
  */
-export function record<TInnerSchema extends ASchema<any>>(
+export function record<TInnerSchema extends ASchema<any, any>>(
     schema: TInnerSchema,
     opts: ASchemaOptions = {},
 ): ARecordSchemaWithAdapters<TInnerSchema> {
@@ -58,6 +58,7 @@ export function record<TInnerSchema extends ASchema<any>>(
     };
     const validator: SchemaValidator<InferRecordType<TInnerSchema>> = {
         output: {},
+        optional: false,
         validate: validateFn,
         parse: parseFn,
         coerce(input: unknown, data) {

--- a/languages/ts/ts-schema/src/lib/recursive.ts
+++ b/languages/ts/ts-schema/src/lib/recursive.ts
@@ -80,10 +80,11 @@ export function recursive<T = any>(
     const id = options.id ?? `TypeRef${recursiveTypeCount}`;
     const recursiveFns: Record<
         string,
-        Omit<SchemaValidator<any>, 'output'>
+        Omit<SchemaValidator<any>, 'output' | 'optional'>
     > = {};
     const validator: SchemaValidator<T> = {
         output: '' as T,
+        optional: false,
         parse(input, context) {
             if (context.depth >= context.maxDepth) {
                 context.errors.push({

--- a/languages/ts/ts-schema/src/lib/string.ts
+++ b/languages/ts/ts-schema/src/lib/string.ts
@@ -21,6 +21,7 @@ export function string(
 ): AScalarSchemaWithAdapters<'string', string> {
     const validator: AScalarSchema<'string', string>[typeof VALIDATOR_KEY] = {
         output: '',
+        optional: false,
         parse: decode,
         coerce,
         validate,

--- a/languages/ts/ts-schema/src/lib/timestamp.ts
+++ b/languages/ts/ts-schema/src/lib/timestamp.ts
@@ -21,6 +21,7 @@ export function timestamp(
 ): AScalarSchemaWithAdapters<'timestamp', Date> {
     const validator: SchemaValidator<Date> = {
         output: new Date(),
+        optional: false,
         validate,
         parse: parse,
         coerce,

--- a/languages/ts/ts-schema/src/schemas.test.ts
+++ b/languages/ts/ts-schema/src/schemas.test.ts
@@ -1,4 +1,11 @@
-import { a, type InferSubType, type InferType } from './_index';
+import {
+    a,
+    InferObjectOptionalKeys,
+    type InferSubType,
+    type InferType,
+    PartialBy,
+    ResolveObject,
+} from './_index';
 
 describe('InferSubType', () => {
     test('Basic Discriminator', () => {
@@ -16,5 +23,36 @@ describe('InferSubType', () => {
         type SchemaTypeB = InferSubType<Schema, 'type', 'B'>;
         assertType<SchemaTypeA>({ id: '', type: 'A' });
         assertType<SchemaTypeB>({ id: '', type: 'B', name: '' });
+    });
+});
+
+describe('Optional Keys', () => {
+    test('OptionalBy<T, K> type inference', () => {
+        type Foo = {
+            foo: string;
+            bar: boolean;
+            baz: number;
+        };
+        type OptionalFoo = ResolveObject<PartialBy<Foo, 'foo'>>;
+        assertType<OptionalFoo>({ bar: true, baz: 0 });
+    });
+    test('OptionalKeys<T> type inference', () => {
+        const input = {
+            foo: a.optional(a.string()),
+            bar: a.boolean(),
+            baz: a.number(),
+        } as const;
+        a.object(input);
+        type Keys = InferObjectOptionalKeys<typeof input>;
+        assertType<Keys>('foo');
+    });
+    test('Inferring Optional Types', () => {
+        const Foo = a.object({
+            foo: a.string(),
+            bar: a.boolean(),
+            baz: a.optional(a.number()),
+        });
+        type Foo = a.infer<typeof Foo>;
+        assertType<Foo>({ foo: '', bar: false });
     });
 });

--- a/languages/ts/ts-schema/src/testSuites.ts
+++ b/languages/ts/ts-schema/src/testSuites.ts
@@ -436,16 +436,16 @@ export const validationTestSuites: Record<
         ],
     },
     'object with optional fields': {
-        schema: a.partial(
-            a.object({
-                id: a.string(),
-                createdAt: a.timestamp(),
-                type: a.stringEnum(['a', 'b']),
-                object: a.object({
+        schema: a.object({
+            id: a.optional(a.string()),
+            createdAt: a.optional(a.timestamp()),
+            type: a.optional(a.stringEnum(['a', 'b'])),
+            object: a.optional(
+                a.object({
                     foo: a.string(),
                 }),
-            }),
-        ),
+            ),
+        }),
         goodInputs: [
             {
                 id: '',
@@ -473,6 +473,53 @@ export const validationTestSuites: Record<
                 createdAt: new Date(),
                 type: 'b',
                 object: [],
+            },
+        ],
+    },
+    'object with undefinable fields': {
+        schema: a.object({
+            id: a.undefinable(a.string()),
+            createdAt: a.undefinable(a.timestamp()),
+            count: a.undefinable(a.number()),
+            isActive: a.undefinable(a.boolean()),
+            tags: a.undefinable(a.array(a.string())),
+            metadata: a.undefinable(a.record(a.string())),
+            unknown: a.undefinable(a.any()),
+        }),
+        goodInputs: [
+            {},
+            {
+                id: undefined,
+                createdAt: undefined,
+                count: undefined,
+                isActive: undefined,
+                tags: undefined,
+                metadata: undefined,
+                unknown: undefined,
+            },
+            {
+                id: '',
+                createdAt: new Date(),
+                count: 0,
+                isActive: true,
+                tags: [],
+                metadata: {
+                    a: 'a',
+                    b: 'b',
+                },
+                unknown: {
+                    blah: true,
+                },
+            },
+        ],
+        badInputs: [
+            'hello world',
+            {
+                id: null,
+                createdAt: 'hello world',
+                count: null,
+                isActive: null,
+                metadata: { a: false },
             },
         ],
     },


### PR DESCRIPTION
Closes #161 