### PR TITLE
refactor: consistent bool properties in app def and type def

### DIFF
--- a/languages/dart/dart-codegen/src/_common.ts
+++ b/languages/dart/dart-codegen/src/_common.ts
@@ -29,7 +29,7 @@ export interface DartProperty {
 }
 
 export function outputIsNullable(schema: Schema, context: CodegenContext) {
-    if (schema.nullable) {
+    if (schema.isNullable) {
         return true;
     }
     if (context.isOptional) {

--- a/languages/dart/dart-codegen/src/array.ts
+++ b/languages/dart/dart-codegen/src/array.ts
@@ -42,7 +42,7 @@ export function dartListFromSchema(
             if (context.isOptional) {
                 return `${input}!.map((_el_) => ${innerType.toJson('_el_', '', '')}).toList()`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${input}?.map((_el_) => ${innerType.toJson('_el_', '', '')}).toList()`;
             }
             return `${input}.map((_el_) => ${innerType.toJson('_el_', '', '')}).toList()`;

--- a/languages/dart/dart-codegen/src/discriminator.ts
+++ b/languages/dart/dart-codegen/src/discriminator.ts
@@ -61,7 +61,7 @@ export function dartSealedClassFromSchema(
             if (context.isOptional) {
                 return `${input}!.toJson()`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${input}?.toJson()`;
             }
             return `${input}.toJson()`;

--- a/languages/dart/dart-codegen/src/enum.ts
+++ b/languages/dart/dart-codegen/src/enum.ts
@@ -43,7 +43,7 @@ export function dartEnumFromSchema(
             if (context.isOptional) {
                 return `${input}!.serialValue`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${input}?.serialValue`;
             }
             return `${input}.serialValue`;
@@ -52,7 +52,7 @@ export function dartEnumFromSchema(
             if (context.isOptional) {
                 return `if (${input} != null) ${target}.add("${key}=\${${input}!.serialValue}")`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target}.add("${key}=\${${input}?.serialValue}")`;
             }
             return `${target}.add("${key}=\${${input}.serialValue}")`;

--- a/languages/dart/dart-codegen/src/object.ts
+++ b/languages/dart/dart-codegen/src/object.ts
@@ -37,7 +37,7 @@ export function dartClassFromSchema(
             if (context.isOptional) {
                 return `${input}!.toJson()`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${input}?.toJson()`;
             }
             return `${input}.toJson()`;

--- a/languages/dart/dart-codegen/src/primitives.ts
+++ b/languages/dart/dart-codegen/src/primitives.ts
@@ -84,7 +84,7 @@ export function dartDateTimeFromSchema(
                 // the null check will happen at the object level
                 return `${input}!.toUtc().toIso8601String()`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${input}?.toUtc().toIso8601String()`;
             }
             return `${input}.toUtc().toIso8601String()`;
@@ -93,7 +93,7 @@ export function dartDateTimeFromSchema(
             if (context.isOptional) {
                 return `if (${input} != null) ${target}.add("${key}=\${${input}!.toUtc().toIso8601String()}")`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target}.add("${key}=\${${input}?.toUtc().toIso8601String()}")`;
             }
             return `${target}.add("${key}=\${${input}.toUtc().toIso8601String()}")`;
@@ -183,7 +183,7 @@ export function dartBigIntFromSchema(
             if (context.isOptional) {
                 return `${input}!.toString()`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${input}?.toString()`;
             }
             return `${input}.toString()`;

--- a/languages/dart/dart-codegen/src/record.ts
+++ b/languages/dart/dart-codegen/src/record.ts
@@ -48,7 +48,7 @@ export function dartMapFromSchema(
             if (context.isOptional) {
                 return `${input}!.map((_key_, _val_) => MapEntry(_key_, ${innerType.toJson('_val_', '', '')},),)`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${input}?.map((_key_, _val_) => MapEntry(_key_, ${innerType.toJson('_val_', '', '')},),)`;
             }
             return `${input}.map((_key_, _val_) => MapEntry(_key_, ${innerType.toJson('_val_', '', '')},),)`;

--- a/languages/dart/dart-codegen/src/ref.ts
+++ b/languages/dart/dart-codegen/src/ref.ts
@@ -36,7 +36,7 @@ export function dartRefFromSchema(
             if (context.isOptional) {
                 return `${input}!.toJson()`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${input}?.toJson()`;
             }
             return `${input}.toJson()`;

--- a/languages/go/go-server/README.md
+++ b/languages/go/go-server/README.md
@@ -14,6 +14,7 @@ Go implementation of [Arri RPC](/README.md). It uses the `net/http` package from
     - [Enums](#enums)
     - [Arrays and Slices](#arrays-and-slices)
     - [Objects](#objects)
+        - [Struct Field Tags](#struct-field-tags)
     - [Maps](#maps)
     - [Discriminated Unions / Tagged Unions](#discriminated-unions--tagged-unions)
     - [Recursive Types](#recursive-types)
@@ -437,6 +438,23 @@ func GetPost(
     arri.RpcError,
 ) {
     // rpc content
+}
+```
+
+#### Struct Field Tags
+
+Arri comes with a number of struct field tags which provide additional metadata to Arri.
+
+```go
+type Foo struct {
+    // manually specify the serialized key name
+    Foo string `key:"foo_foo"`
+
+    // add a description which will become doc comments in the target client(s)
+    Bar string `description:"this is a description"`
+
+    // set this field as deprecated
+    Baz bool `arri:"deprecated"`
 }
 ```
 

--- a/languages/go/go-server/decode_json.go
+++ b/languages/go/go-server/decode_json.go
@@ -116,7 +116,7 @@ func DecodeJSON[T any](data []byte, v *T, options EncodingOptions) *DecoderError
 	}
 	maxDepth := options.MaxDepth
 	if maxDepth == 0 {
-		maxDepth = 10000
+		maxDepth = 200
 	}
 	dc := DecoderContext{
 		MaxDepth:  maxDepth,

--- a/languages/go/go-server/encode_json.go
+++ b/languages/go/go-server/encode_json.go
@@ -17,15 +17,21 @@ type EncodingContext struct {
 	InstancePath       string
 	SchemaPath         string
 	CurrentDepth       uint32
+	MaxDepth           uint32
 	HasKeys            bool
 	EnumValues         map[string][]string
 	DiscriminatorKey   string
 	DiscriminatorValue string
 }
 
-func NewEncodingContext(keyCasing string) *EncodingContext {
+func NewEncodingContext(options EncodingOptions) *EncodingContext {
+	maxDepth := options.MaxDepth
+	if maxDepth == 0 {
+		maxDepth = 200
+	}
 	return &EncodingContext{
-		KeyCasing:    keyCasing,
+		KeyCasing:    options.KeyCasing,
+		MaxDepth:     maxDepth,
 		Buffer:       []byte{},
 		InstancePath: "",
 		SchemaPath:   "",
@@ -35,7 +41,7 @@ func NewEncodingContext(keyCasing string) *EncodingContext {
 }
 
 func EncodeJSON(input any, options EncodingOptions) ([]byte, error) {
-	ctx := NewEncodingContext(options.KeyCasing)
+	ctx := NewEncodingContext(options)
 	value := reflect.ValueOf(input)
 	err := encodeValueToJSON(value, ctx)
 	if err != nil {
@@ -45,6 +51,9 @@ func EncodeJSON(input any, options EncodingOptions) ([]byte, error) {
 }
 
 func encodeValueToJSON(v reflect.Value, c *EncodingContext) error {
+	if c.CurrentDepth > c.MaxDepth {
+		return fmt.Errorf("max depth of %s exceeded", c.MaxDepth)
+	}
 	kind := v.Kind()
 	switch kind {
 	case reflect.String:
@@ -369,7 +378,7 @@ func encodeMapToJSON(v reflect.Value, c *EncodingContext) error {
 	keyVals := []string{}
 	for _, key := range v.MapKeys() {
 		if key.Kind() != reflect.String {
-			return fmt.Errorf("error at %s, map keys must be strings", instancePath)
+			return fmt.Errorf("error at %+v, map keys must be strings", instancePath)
 		}
 		keyName := key.String()
 		keys[keyName] = key

--- a/languages/go/go-server/encode_json.go
+++ b/languages/go/go-server/encode_json.go
@@ -52,7 +52,7 @@ func EncodeJSON(input any, options EncodingOptions) ([]byte, error) {
 
 func encodeValueToJSON(v reflect.Value, c *EncodingContext) error {
 	if c.CurrentDepth > c.MaxDepth {
-		return fmt.Errorf("max depth of %s exceeded", c.MaxDepth)
+		return fmt.Errorf("max depth of %+v exceeded", c.MaxDepth)
 	}
 	kind := v.Kind()
 	switch kind {

--- a/languages/go/go-server/type_def.go
+++ b/languages/go/go-server/type_def.go
@@ -29,9 +29,11 @@ const (
 type Type = string
 
 type TypeDefMetadata struct {
-	Id           Option[string] `key:"id"`
-	Description  Option[string] `key:"description"`
-	IsDeprecated Option[bool]   `key:"isDeprecated"`
+	Id              Option[string] `key:"id"`
+	Description     Option[string] `key:"description"`
+	IsDeprecated    Option[bool]   `key:"isDeprecated"`
+	DeprecatedNote  Option[string] `key:"deprecatedNote"`
+	DeprecatedSince Option[string] `key:"deprecatedSince"`
 }
 
 type TypeDef struct {
@@ -324,6 +326,12 @@ func structToTypeDef(input reflect.Type, context TypeDefContext) (*TypeDef, erro
 				deprecated = true
 			}
 		}
+		deprecatedNote := None[string]()
+		deprecatedAnnotation := field.Tag.Get("deprecated")
+		if len(deprecatedAnnotation) > 0 {
+			deprecated = true
+			deprecatedNote.Set(deprecatedAnnotation)
+		}
 		fieldType := field.Type
 		description := field.Tag.Get("description")
 		enumValues := None[Option[[]string]]()
@@ -382,9 +390,10 @@ func structToTypeDef(input reflect.Type, context TypeDefContext) (*TypeDef, erro
 			}
 			if desc.IsSome() || isDeprecated.IsSome() {
 				fieldResult.Metadata.Set(TypeDefMetadata{
-					Id:           fieldResult.Metadata.Unwrap().Id,
-					Description:  desc,
-					IsDeprecated: isDeprecated,
+					Id:             fieldResult.Metadata.Unwrap().Id,
+					Description:    desc,
+					IsDeprecated:   isDeprecated,
+					DeprecatedNote: deprecatedNote,
 				})
 			}
 		}

--- a/languages/go/go-server/type_def.go
+++ b/languages/go/go-server/type_def.go
@@ -36,13 +36,13 @@ type TypeDefMetadata struct {
 
 type TypeDef struct {
 	Metadata           Option[TypeDefMetadata]     `key:"metadata" `
-	Nullable           Option[bool]                `key:"nullable"`
+	IsNullable         Option[bool]                `key:"isNullable"`
 	Type               Option[Type]                `key:"type"`
 	Enum               Option[[]string]            `key:"enum"`
 	Elements           Option[*TypeDef]            `key:"elements"`
 	Properties         Option[OrderedMap[TypeDef]] `key:"properties"`
 	OptionalProperties Option[OrderedMap[TypeDef]] `key:"optionalProperties"`
-	Strict             Option[bool]                `key:"strict"`
+	IsStrict           Option[bool]                `key:"isStrict"`
 	Values             Option[*TypeDef]            `key:"values"`
 	Discriminator      Option[string]              `key:"discriminator"`
 	Mapping            Option[OrderedMap[TypeDef]] `key:"mapping"`
@@ -174,11 +174,11 @@ func typeToTypeDef(input reflect.Type, context TypeDefContext) (*TypeDef, error)
 		}
 		if input.Name() == "Time" {
 			t := Timestamp
-			return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+			return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 		}
 		return structToTypeDef(input, context)
 	case reflect.Interface:
-		return &TypeDef{Nullable: context.IsNullable}, nil
+		return &TypeDef{IsNullable: context.IsNullable}, nil
 	default:
 		return nil, fmt.Errorf("error at %s. %s is not a supported type", context.InstancePath, input.Kind())
 	}
@@ -189,43 +189,43 @@ func primitiveTypeToTypeDef(value reflect.Type, context TypeDefContext) (*TypeDe
 	switch kind {
 	case reflect.Bool:
 		t := Boolean
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Int:
 		t := Int64
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Int8:
 		t := Int8
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Int16:
 		t := Int16
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Int32:
 		t := Int32
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Int64:
 		t := Int64
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Uint:
 		t := Uint64
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Uint8:
 		t := Uint8
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Uint16:
 		t := Uint16
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Uint32:
 		t := Uint32
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Uint64:
 		t := Uint64
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Float32:
 		t := Float32
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.Float64:
 		t := Float64
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	case reflect.String:
 		if context.EnumValues.IsSome() {
 			metadata := None[TypeDefMetadata]()
@@ -233,13 +233,13 @@ func primitiveTypeToTypeDef(value reflect.Type, context TypeDefContext) (*TypeDe
 				metadata = Some(TypeDefMetadata{Id: Some(context.EnumName.Unwrap())})
 			}
 			return &TypeDef{
-				Enum:     context.EnumValues,
-				Nullable: context.IsNullable,
-				Metadata: metadata,
+				Enum:       context.EnumValues,
+				IsNullable: context.IsNullable,
+				Metadata:   metadata,
 			}, nil
 		}
 		t := String
-		return &TypeDef{Type: Some(t), Nullable: context.IsNullable}, nil
+		return &TypeDef{Type: Some(t), IsNullable: context.IsNullable}, nil
 	default:
 		return nil, fmt.Errorf("error at %s. '%s' is not a supported primitive type", context.InstancePath, kind)
 	}
@@ -281,7 +281,7 @@ func structToTypeDef(input reflect.Type, context TypeDefContext) (*TypeDef, erro
 		for i := 0; i < len(context.ParentStructs); i++ {
 			name := context.ParentStructs[i]
 			if name == typeId.Unwrap() {
-				return &TypeDef{Ref: typeId, Nullable: context.IsNullable}, nil
+				return &TypeDef{Ref: typeId, IsNullable: context.IsNullable}, nil
 			}
 		}
 		context.ParentStructs = append(context.ParentStructs, typeId.Unwrap())
@@ -398,12 +398,12 @@ func structToTypeDef(input reflect.Type, context TypeDefContext) (*TypeDef, erro
 		return &TypeDef{
 			Properties:         Some(requiredFields),
 			OptionalProperties: Some(optionalFields),
-			Nullable:           context.IsNullable,
+			IsNullable:         context.IsNullable,
 			Metadata:           Some(TypeDefMetadata{Id: typeId})}, nil
 	}
 	return &TypeDef{
 		Properties: Some(requiredFields),
-		Nullable:   context.IsNullable,
+		IsNullable: context.IsNullable,
 		Metadata:   Some(TypeDefMetadata{Id: typeId}),
 	}, nil
 }
@@ -487,7 +487,7 @@ func taggedUnionToTypeDef(name Option[string], input reflect.Type, context TypeD
 	return &TypeDef{
 		Discriminator: Some(discriminatorKey),
 		Mapping:       Some(mapping),
-		Nullable:      context.IsNullable,
+		IsNullable:    context.IsNullable,
 		Metadata:      Some(TypeDefMetadata{Id: name}),
 	}, nil
 }
@@ -516,7 +516,7 @@ func arrayToTypeDef(input reflect.Type, context TypeDefContext) (*TypeDef, error
 		return nil, err
 	}
 	r := Some(subTypeResult)
-	return &TypeDef{Elements: r, Nullable: context.IsNullable}, nil
+	return &TypeDef{Elements: r, IsNullable: context.IsNullable}, nil
 }
 
 func mapToTypeDef(input reflect.Type, context TypeDefContext) (*TypeDef, error) {
@@ -551,5 +551,5 @@ func mapToTypeDef(input reflect.Type, context TypeDefContext) (*TypeDef, error) 
 		return nil, err
 	}
 	r := Some(subTypeResult)
-	return &TypeDef{Values: r, Nullable: context.IsNullable}, nil
+	return &TypeDef{Values: r, IsNullable: context.IsNullable}, nil
 }

--- a/languages/go/go-server/type_def_test.go
+++ b/languages/go/go-server/type_def_test.go
@@ -27,7 +27,7 @@ func TestStringToTypeDef(t *testing.T) {
 		t.Fatal(deepEqualErrString(result, expectedResult))
 		return
 	}
-	expectedResult.Nullable = arri.Some(true)
+	expectedResult.IsNullable = arri.Some(true)
 	if !reflect.DeepEqual(nullableResult, expectedResult) {
 		t.Fatal(deepEqualErrString(nullableResult, expectedResult))
 		return
@@ -48,7 +48,7 @@ func TestArrayToTypeDef(t *testing.T) {
 		return
 	}
 	nullableResult, nullableErr := arri.ToTypeDef(arri.Null[[]string](), options)
-	expectedResult.Nullable = arri.Some(true)
+	expectedResult.IsNullable = arri.Some(true)
 	if nullableErr != nil {
 		t.Fatal(nullableErr.Error())
 		return
@@ -111,8 +111,8 @@ func TestOrderedMapToTypeDef(t *testing.T) {
 
 func TestNullableStringToTypeDef(t *testing.T) {
 	expectedResult := &arri.TypeDef{
-		Type:     arri.Some(arri.String),
-		Nullable: arri.Some(true),
+		Type:       arri.Some(arri.String),
+		IsNullable: arri.Some(true),
 	}
 	result, err := arri.ToTypeDef(arri.Null[string](), options)
 	if err != nil {

--- a/languages/go/go-server/type_helpers.go
+++ b/languages/go/go-server/type_helpers.go
@@ -159,7 +159,7 @@ func (s Nullable[T]) TypeDef(tc TypeDefContext) (*TypeDef, error) {
 	if err != nil {
 		return nil, err
 	}
-	def.Nullable.Set(true)
+	def.IsNullable.Set(true)
 	return def, nil
 }
 

--- a/languages/kotlin/kotlin-codegen/src/_common.ts
+++ b/languages/kotlin/kotlin-codegen/src/_common.ts
@@ -154,7 +154,7 @@ export function instanceDepth(context: CodegenContext) {
 }
 
 export function isNullable(schema: Schema, context: CodegenContext) {
-    return schema.nullable === true || context.isOptional === true;
+    return schema.isNullable === true || context.isOptional === true;
 }
 
 export function getCodeComment(

--- a/languages/kotlin/kotlin-codegen/src/any.ts
+++ b/languages/kotlin/kotlin-codegen/src/any.ts
@@ -24,7 +24,7 @@ export function kotlinAnyFromSchema(
                     else -> ${input} 
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `when (${input}) {
                     JsonNull -> null
                     null -> null
@@ -37,7 +37,7 @@ export function kotlinAnyFromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target} += when (${input}) {
                     null -> "null"
                     else -> JsonInstance.encodeToString(${input})

--- a/languages/kotlin/kotlin-codegen/src/array.ts
+++ b/languages/kotlin/kotlin-codegen/src/array.ts
@@ -58,7 +58,7 @@ export function kotlinArrayFromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (${input} == null) {
                     ${target} += "null"
                 } else {

--- a/languages/kotlin/kotlin-codegen/src/discriminator.ts
+++ b/languages/kotlin/kotlin-codegen/src/discriminator.ts
@@ -65,7 +65,7 @@ export function kotlinDiscriminatorFromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target} += ${input}?.toJson()`;
             }
             return `${target} += ${input}.toJson()`;

--- a/languages/kotlin/kotlin-codegen/src/enum.ts
+++ b/languages/kotlin/kotlin-codegen/src/enum.ts
@@ -84,7 +84,7 @@ export function kotlinEnumFromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target} += when (${input}) {
                     is ${prefixedClassName} -> "\\"\${${input}.serialValue}\\""
                     else -> "null"
@@ -98,7 +98,7 @@ export function kotlinEnumFromSchema(
                     ${target}.add("${key}=\${${input}.serialValue}")
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target}.add("${key}=\${${input}?.serialValue}")`;
             }
             return `${target}.add("${key}=\${${input}.serialValue}")`;

--- a/languages/kotlin/kotlin-codegen/src/map.ts
+++ b/languages/kotlin/kotlin-codegen/src/map.ts
@@ -42,7 +42,7 @@ export function kotlinMapFromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (${input} == null) {
                     ${target} += "null"
                 } else {

--- a/languages/kotlin/kotlin-codegen/src/object.ts
+++ b/languages/kotlin/kotlin-codegen/src/object.ts
@@ -43,7 +43,7 @@ export function kotlinObjectFromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target} += ${input}?.toJson()`;
             }
             return `${target} += ${input}.toJson()`;

--- a/languages/kotlin/kotlin-codegen/src/primitives.ts
+++ b/languages/kotlin/kotlin-codegen/src/primitives.ts
@@ -52,7 +52,7 @@ export function kotlinStringFromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target} += when (${input}) {
                     is String -> buildString { printQuoted(${input}) }
                     else -> "null"
@@ -122,7 +122,7 @@ export function kotlinTimestampFromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target} += when (${input}) {
                     is Instant -> "\\"\${timestampFormatter.format(${input})}\\""
                     else -> "null"
@@ -140,7 +140,7 @@ export function kotlinTimestampFromSchema(
                 )
             }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target}.add(
                     "${key}=\${
                         when (${input}) {
@@ -349,7 +349,7 @@ export function kotlinInt64FromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target} += when (${input}) {
                     is Long -> "\\"\${${input}}\\""
                     else -> "null"
@@ -487,7 +487,7 @@ export function kotlinUint64FromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target} += when (${input}) {
                     is ULong -> "\\"\${${input}}\\""
                     else -> "null"

--- a/languages/kotlin/kotlin-codegen/src/ref.ts
+++ b/languages/kotlin/kotlin-codegen/src/ref.ts
@@ -30,7 +30,7 @@ export function kotlinRefFromSchema(
             }`;
         },
         toJson(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target} += ${input}?.toJson()`;
             }
             return `${target} += ${input}.toJson()`;

--- a/languages/rust/rust-codegen/src/_common.ts
+++ b/languages/rust/rust-codegen/src/_common.ts
@@ -129,7 +129,7 @@ export function outputIsOptionType(
     schema: Schema,
     context: GeneratorContext,
 ): boolean {
-    return schema.nullable === true || context.isOptional === true;
+    return schema.isNullable === true || context.isOptional === true;
 }
 
 export function getTypeName(schema: Schema, context: GeneratorContext): string {

--- a/languages/rust/rust-codegen/src/array.ts
+++ b/languages/rust/rust-codegen/src/array.ts
@@ -30,7 +30,7 @@ export default function rustArrayFromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {

--- a/languages/rust/rust-codegen/src/enum.ts
+++ b/languages/rust/rust-codegen/src/enum.ts
@@ -27,7 +27,7 @@ export default function rustEnumFromSchema(
         typeId: enumName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -58,7 +58,7 @@ export default function rustEnumFromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}.serial_value()));

--- a/languages/rust/rust-codegen/src/object.ts
+++ b/languages/rust/rust-codegen/src/object.ts
@@ -30,7 +30,7 @@ export default function rustObjectFromSchema(
         typeId: structName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {

--- a/languages/rust/rust-codegen/src/primitives.ts
+++ b/languages/rust/rust-codegen/src/primitives.ts
@@ -18,7 +18,7 @@ export function rustStringFromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -45,7 +45,7 @@ export function rustStringFromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -72,7 +72,7 @@ export function rustBooleanFromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -99,7 +99,7 @@ export function rustBooleanFromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -128,7 +128,7 @@ export function rustTimestampFromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -166,7 +166,7 @@ export function rustTimestampFromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!(
@@ -199,7 +199,7 @@ export function rustF32FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -231,7 +231,7 @@ export function rustF32FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -258,7 +258,7 @@ export function rustF64FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -290,7 +290,7 @@ export function rustF64FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -317,7 +317,7 @@ export function rustI8FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -352,7 +352,7 @@ export function rustI8FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -379,7 +379,7 @@ export function rustU8FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -414,7 +414,7 @@ export function rustU8FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -441,7 +441,7 @@ export function rustI16FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -476,7 +476,7 @@ export function rustI16FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -503,7 +503,7 @@ export function rustU16FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -538,7 +538,7 @@ export function rustU16FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -565,7 +565,7 @@ export function rustI32FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -600,7 +600,7 @@ export function rustI32FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -627,7 +627,7 @@ export function rustU32FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -662,7 +662,7 @@ export function rustU32FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -689,7 +689,7 @@ export function rustI64FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -721,7 +721,7 @@ export function rustI64FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));
@@ -748,7 +748,7 @@ export function rustU64FromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {
@@ -780,7 +780,7 @@ export function rustU64FromSchema(
                     _ => {}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `match ${input} {
                     Some(${innerKey}) => {
                         ${target}.push(format!("${key}={}", ${innerKey}));

--- a/languages/rust/rust-codegen/src/record.ts
+++ b/languages/rust/rust-codegen/src/record.ts
@@ -30,7 +30,7 @@ export default function rustRecordFromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             if (isOptionType) {

--- a/languages/rust/rust-codegen/src/ref.ts
+++ b/languages/rust/rust-codegen/src/ref.ts
@@ -32,7 +32,7 @@ export default function rustRefFromSchema(
         typeId: typeName,
         finalTypeName: typeName,
         defaultValue,
-        isNullable: schema.nullable ?? false,
+        isNullable: schema.isNullable ?? false,
         fromJsonTemplate(input, key) {
             const innerKey = validRustIdentifier(`${key}_val`);
             const valFromJson = (input: string) => {

--- a/languages/swift/swift-codegen/src/_common.ts
+++ b/languages/swift/swift-codegen/src/_common.ts
@@ -43,7 +43,7 @@ export function isNullableType(
     schema: Schema,
     context: GeneratorContext,
 ): boolean {
-    return schema.nullable === true || context.isOptional === true;
+    return schema.isNullable === true || context.isOptional === true;
 }
 
 export function validTypeName(input: string): string {

--- a/languages/swift/swift-codegen/src/any.ts
+++ b/languages/swift/swift-codegen/src/any.ts
@@ -8,7 +8,7 @@ export function swiftAnyFromSchema(
 ): SwiftProperty {
     const isNullable = isNullableType(schema, context);
     let defaultValue = 'JSON()';
-    if (schema.nullable) {
+    if (schema.isNullable) {
         defaultValue = 'JSON(parseJSON: "null")';
     } else if (context.isOptional) {
         defaultValue = '';

--- a/languages/swift/swift-codegen/src/array.ts
+++ b/languages/swift/swift-codegen/src/array.ts
@@ -45,7 +45,7 @@ export function swiftArrayFromSchema(
 ${mainContent}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.array != nil {
 ${mainContent}
                 }`;
@@ -61,7 +61,7 @@ ${mainContent}
                 ${subType.toJsonTemplate(`__element`, target)}
             }
             ${target} += "]"`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${mainContent}
                 } else {

--- a/languages/swift/swift-codegen/src/discriminator.ts
+++ b/languages/swift/swift-codegen/src/discriminator.ts
@@ -38,7 +38,7 @@ export function swiftTaggedUnionFromSchema(
                     ${target} = ${prefixedTypeName}(json: ${input})
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.dictionary != nil {
                     ${target} = ${prefixedTypeName}(json: ${input})
                 }`;
@@ -49,7 +49,7 @@ export function swiftTaggedUnionFromSchema(
             if (context.isOptional) {
                 return `        ${target} += ${input}!.toJSONString()`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target} += ${input}!.toJSONString()
                 } else {

--- a/languages/swift/swift-codegen/src/enum.ts
+++ b/languages/swift/swift-codegen/src/enum.ts
@@ -35,7 +35,7 @@ export function swiftEnumFromSchema(
                     ${target} = ${prefixedTypeName}(serialValue: ${input}.string ?? "")
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.string != nil {
                     ${target} = ${prefixedTypeName}(serialValue: ${input}.string ?? "")
                 }`;
@@ -46,7 +46,7 @@ export function swiftEnumFromSchema(
             if (context.isOptional) {
                 return `        ${target} += "\\"\\(${input}!.serialValue())\\""`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target} += "\\"\\(${input}!.serialValue())\\""
                 } else {
@@ -61,7 +61,7 @@ export function swiftEnumFromSchema(
                     ${target}.append(URLQueryItem(name: "${key}", value: ${input}!.serialValue()))
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target}.append(URLQueryItem(name: "${key}", value: ${input}!.serialValue()))
                 } else {

--- a/languages/swift/swift-codegen/src/object.ts
+++ b/languages/swift/swift-codegen/src/object.ts
@@ -30,7 +30,7 @@ export function swiftObjectFromSchema(
                     ${target} = ${prefixedTypeName}(json: ${input})
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.dictionary != nil {
                     ${target} = ${prefixedTypeName}(json: ${input})
                 }`;
@@ -41,7 +41,7 @@ export function swiftObjectFromSchema(
             if (context.isOptional) {
                 return `        ${target} += ${input}!.toJSONString()`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target} += ${input}!.toJSONString()
                 } else {

--- a/languages/swift/swift-codegen/src/primitives.ts
+++ b/languages/swift/swift-codegen/src/primitives.ts
@@ -21,7 +21,7 @@ export function swiftStringFromSchema(
             ${target} = ${input}.string    
         }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.string != nil {
             ${target} = ${input}.string
         }`;
@@ -32,7 +32,7 @@ export function swiftStringFromSchema(
             if (context.isOptional) {
                 return `        ${target} += serializeString(input: ${input}!)`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target} += serializeString(input: ${input}!)
                 } else {
@@ -47,7 +47,7 @@ export function swiftStringFromSchema(
                     ${target}.append(URLQueryItem(name: "${key}", value: ${input}!))
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target}.append(URLQueryItem(name: "${key}", value: ${input}!))
                 } else {
@@ -79,7 +79,7 @@ export function swiftBooleanFromSchema(
                     ${target} = ${input}.bool
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.bool != nil {
                     ${target} = ${input}.bool
                 }`;
@@ -90,7 +90,7 @@ export function swiftBooleanFromSchema(
             if (context.isOptional) {
                 return `${target} += "\\(${input}!)"`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target} += "\\(${input}!)"
                 } else {
@@ -105,7 +105,7 @@ export function swiftBooleanFromSchema(
                     ${target}.append(URLQueryItem(name: "${key}", value: "\\(${input}!)"))
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target}.append(URLQueryItem(name: "${key}", value: "\\(${input}!)"))
                 } else {
@@ -137,7 +137,7 @@ export function swiftTimestampFromSchema(
                     ${target} = parseDate(${input}.string ?? "") ?? Date()
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.string != nil {
                     ${target} = parseDate(${input}.string ?? "") ?? Date()
                 }`;
@@ -148,7 +148,7 @@ export function swiftTimestampFromSchema(
             if (context.isOptional) {
                 return `        ${target} += serializeDate(${input}!)`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target} += serializeDate(${input}!)
                 } else {
@@ -163,7 +163,7 @@ export function swiftTimestampFromSchema(
                     ${target}.append(URLQueryItem(name: "${key}", value: serializeDate(${input}!, withQuotes: false)))
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target}.append(URLQueryItem(name: "${key}", value: serializeDate(${input}!, withQuotes: false)))
                 } else {
@@ -196,7 +196,7 @@ export function swiftNumberFromSchema(
                     ${target} = ${input}.${jsonAccessor}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.${jsonAccessor} != nil {
                     ${target} = ${input}.${jsonAccessor}
                 }`;
@@ -207,7 +207,7 @@ export function swiftNumberFromSchema(
             if (context.isOptional) {
                 return `        ${target} += "\\(${input}!)"`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target} += "\\(${input}!)"
                 } else {
@@ -222,7 +222,7 @@ export function swiftNumberFromSchema(
                     ${target}.append(URLQueryItem(name: "${key}", value: "\\(${input}!)"))
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target}.append(URLQueryItem(name: "${key}", value: "\\(${input}!)"))
                 } else {
@@ -253,7 +253,7 @@ export function swiftLargeIntFromSchema(
                     ${target} = ${typeName}(${input}.string ?? "0")
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.string != nil {
                     ${target} = ${typeName}(${input}.string ?? "0")
                 }`;
@@ -264,7 +264,7 @@ export function swiftLargeIntFromSchema(
             if (context.isOptional) {
                 return `        ${target} += "\\"\\(${input}!)\\""`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target} += "\\"\\(${input}!)\\""
                 } else {
@@ -279,7 +279,7 @@ export function swiftLargeIntFromSchema(
                     ${target}.append(URLQueryItem(name: "${key}", value: "\\(${input}!)"))
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input} != nil {
                     ${target}.append(URLQueryItem(name: "${key}", value: "\\(${input}!)"))
                 } else {

--- a/languages/swift/swift-codegen/src/record.ts
+++ b/languages/swift/swift-codegen/src/record.ts
@@ -44,7 +44,7 @@ export function swiftDictionaryFromSchema(
 ${mainContent}
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `        if ${input}.dictionary != nil {
 ${mainContent}
                 }`;
@@ -61,7 +61,7 @@ ${mainContent}
                 ${subType.toJsonTemplate('__value', target)}
             }
             ${target} += "}"`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if ${input} != nil {
                     ${mainContent}
                 } else {

--- a/languages/swift/swift-codegen/src/ref.ts
+++ b/languages/swift/swift-codegen/src/ref.ts
@@ -27,7 +27,7 @@ export function swiftRefFromSchema(
                     ${target} = ${prefixedTypeName}(json: ${input})
                 }`;
             }
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if ${input}.dictionary != nil {
                     ${target} = ${prefixedTypeName}(json: ${input})
                 }`;
@@ -36,7 +36,7 @@ export function swiftRefFromSchema(
         },
         toJsonTemplate(input, target) {
             const mainContent = `${target} += ${input}${isNullable ? '!' : ''}.toJSONString()`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if ${input} != nil {
                     ${mainContent}
                 } else {

--- a/languages/ts/ts-codegen/src/any.ts
+++ b/languages/ts/ts-codegen/src/any.ts
@@ -7,7 +7,7 @@ export function tsAnyFromSchema(
     context: CodegenContext,
 ): TsProperty {
     const typeName = 'any';
-    const defaultValue = schema.nullable ? 'null' : 'undefined';
+    const defaultValue = schema.isNullable ? 'null' : 'undefined';
     return {
         typeName,
         defaultValue,

--- a/languages/ts/ts-codegen/src/array.ts
+++ b/languages/ts/ts-codegen/src/array.ts
@@ -21,16 +21,16 @@ export function tsArrayFromSchema(
         rpcGenerators: context.rpcGenerators,
     });
     const typeName = `(${innerType.typeName})[]`;
-    const defaultValue = schema.nullable ? 'null' : '[]';
+    const defaultValue = schema.isNullable ? 'null' : '[]';
     return {
-        typeName: schema.nullable ? `${typeName} | null` : typeName,
+        typeName: schema.isNullable ? `${typeName} | null` : typeName,
         defaultValue,
         validationTemplate(input) {
             const mainPart = `Array.isArray(${input}) 
                 && ${input}.every(
                     (_element) => ${innerType.validationTemplate('_element')}
             )`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `((${mainPart}) || 
                 ${input} === null)`;
             }
@@ -51,7 +51,7 @@ export function tsArrayFromSchema(
         toJsonTemplate(input, target) {
             const elVar = `_${camelCase(validVarName(input.split('.').join('_')), { normalize: true })}El`;
             const elKeyVar = `${elVar}Key`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (${input} !== null) {
                     ${target} += '[';
                     for (let i = 0; i < ${input}.length; i++) {

--- a/languages/ts/ts-codegen/src/discriminator.ts
+++ b/languages/ts/ts-codegen/src/discriminator.ts
@@ -14,18 +14,18 @@ export function tsTaggedUnionFromSchema(
 ): TsProperty {
     const typeName = getTsTypeName(schema, context);
     const prefixedTypeName = `${context.typePrefix}${typeName}`;
-    const defaultValue = schema.nullable
+    const defaultValue = schema.isNullable
         ? 'null'
         : `$$${prefixedTypeName}.new()`;
 
     const result: TsProperty = {
-        typeName: schema.nullable
+        typeName: schema.isNullable
             ? `${prefixedTypeName} | null`
             : prefixedTypeName,
         defaultValue,
         validationTemplate(input: string): string {
             const mainPart = `$$${prefixedTypeName}.validate(${input})`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `(${mainPart} || ${input} === null)`;
             }
             return mainPart;
@@ -38,7 +38,7 @@ export function tsTaggedUnionFromSchema(
             }`;
         },
         toJsonTemplate(input: string, target: string, _key: string): string {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (${input} != null) {
                     ${target} += $$${prefixedTypeName}.toJsonString(${input});
                 } else {

--- a/languages/ts/ts-codegen/src/enum.ts
+++ b/languages/ts/ts-codegen/src/enum.ts
@@ -17,17 +17,17 @@ export function tsEnumFromSchema(
         );
     const enumName = getTsTypeName(schema, context);
     const prefixedEnumName = `${context.typePrefix}${enumName}`;
-    const typeName = schema.nullable
+    const typeName = schema.isNullable
         ? `${prefixedEnumName} | null`
         : prefixedEnumName;
-    const defaultValue = schema.nullable
+    const defaultValue = schema.isNullable
         ? 'null'
         : `$$${prefixedEnumName}.new()`;
     const result: TsProperty = {
         typeName,
         defaultValue,
         validationTemplate(input) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `($$${prefixedEnumName}.validate(${input}) || ${input} === null)`;
             }
             return `$$${prefixedEnumName}.validate(${input})`;
@@ -40,7 +40,7 @@ export function tsEnumFromSchema(
             }`;
         },
         toJsonTemplate(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (typeof ${input} === 'string') {
                     ${target} += \`"\${${input}}"\`;
                 } else {

--- a/languages/ts/ts-codegen/src/object.ts
+++ b/languages/ts/ts-codegen/src/object.ts
@@ -15,16 +15,16 @@ export function tsObjectFromSchema(
 ): TsProperty {
     const typeName = getTsTypeName(schema, context);
     const prefixedTypeName = `${context.typePrefix}${typeName}`;
-    const defaultValue = schema.nullable
+    const defaultValue = schema.isNullable
         ? 'null'
         : `$$${prefixedTypeName}.new()`;
     const result: TsProperty = {
-        typeName: schema.nullable
+        typeName: schema.isNullable
             ? `${prefixedTypeName} | null`
             : prefixedTypeName,
         defaultValue,
         validationTemplate(input) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `($$${prefixedTypeName}.validate(${input}) || ${input} === null)`;
             }
             return `$$${prefixedTypeName}.validate(${input})`;
@@ -37,7 +37,7 @@ export function tsObjectFromSchema(
             }`;
         },
         toJsonTemplate(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (${input} !== null) {
                     ${target} += $$${prefixedTypeName}.toJsonString(${input}); 
                 } else {

--- a/languages/ts/ts-codegen/src/primitives.ts
+++ b/languages/ts/ts-codegen/src/primitives.ts
@@ -6,13 +6,13 @@ export function tsStringFromSchema(
     schema: SchemaFormType,
     _context: CodegenContext,
 ): TsProperty {
-    const typeName = schema.nullable ? 'string | null' : 'string';
-    const defaultValue = schema.nullable ? 'null' : '""';
+    const typeName = schema.isNullable ? 'string | null' : 'string';
+    const defaultValue = schema.isNullable ? 'null' : '""';
     return {
         typeName,
         defaultValue,
         validationTemplate(input) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `(typeof ${input} === 'string' || ${input} === null)`;
             }
             return `typeof ${input} === 'string'`;
@@ -25,7 +25,7 @@ export function tsStringFromSchema(
             }`;
         },
         toJsonTemplate(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (typeof ${input} === 'string') {
                     ${target} += serializeString(${input});
                 } else {
@@ -45,13 +45,13 @@ export function tsBooleanFromSchema(
     schema: SchemaFormType,
     _context: CodegenContext,
 ): TsProperty {
-    const typeName = schema.nullable ? `boolean | null` : 'boolean';
-    const defaultValue = schema.nullable ? `null` : 'false';
+    const typeName = schema.isNullable ? `boolean | null` : 'boolean';
+    const defaultValue = schema.isNullable ? `null` : 'false';
     return {
         typeName,
         defaultValue,
         validationTemplate(input) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `(typeof ${input} === 'boolean' || ${input} === null)`;
             }
             return `typeof ${input} === 'boolean'`;
@@ -77,13 +77,13 @@ export function tsDateFromSchema(
     schema: SchemaFormType,
     _context: CodegenContext,
 ): TsProperty {
-    const typeName = schema.nullable ? `Date | null` : 'Date';
-    const defaultValue = schema.nullable ? `null` : 'new Date()';
+    const typeName = schema.isNullable ? `Date | null` : 'Date';
+    const defaultValue = schema.isNullable ? `null` : 'new Date()';
     return {
         typeName,
         defaultValue,
         validationTemplate(input) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `(${input} instanceof Date || ${input} === null)`;
             }
             return `${input} instanceof Date`;
@@ -98,7 +98,7 @@ export function tsDateFromSchema(
             }`;
         },
         toJsonTemplate(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (${input} instanceof Date) {
                     ${target} += \`"\${${input}.toISOString()}"\`
                 } else {
@@ -108,7 +108,7 @@ export function tsDateFromSchema(
             return `${target} += \`"\${${input}.toISOString()}"\``;
         },
         toQueryStringTemplate(input, target, key) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `${target}.push(\`${key}=\${${input}?.toISOString()}\`)`;
             }
             return `${target}.push(\`${key}=\${${input}.toISOString()}\`)`;
@@ -121,13 +121,13 @@ export function tsFloatFromSchema(
     schema: SchemaFormType,
     _context: CodegenContext,
 ): TsProperty {
-    const typeName = schema.nullable ? 'number | null' : 'number';
-    const defaultValue = schema.nullable ? 'null' : '0';
+    const typeName = schema.isNullable ? 'number | null' : 'number';
+    const defaultValue = schema.isNullable ? 'null' : '0';
     return {
         typeName,
         defaultValue,
         validationTemplate(input) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `(typeof ${input} === 'number' || ${input} === null)`;
             }
             return `typeof ${input} === 'number'`;
@@ -154,8 +154,8 @@ export function tsIntFromSchema(
     intType: 'int8' | 'uint8' | 'int16' | 'uint16' | 'int32' | 'uint32',
     _context: CodegenContext,
 ): TsProperty {
-    const typeName = schema.nullable ? 'number | null' : 'number';
-    const defaultValue = schema.nullable ? 'null' : '0';
+    const typeName = schema.isNullable ? 'number | null' : 'number';
+    const defaultValue = schema.isNullable ? 'null' : '0';
     let min: string;
     let max: string;
     switch (intType) {
@@ -192,7 +192,7 @@ export function tsIntFromSchema(
         defaultValue,
         validationTemplate(input) {
             const mainPart = `typeof ${input} === 'number' && Number.isInteger(${input}) && ${input} >= ${min} && ${input} <= ${max}`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `((${mainPart}) || ${input} === null)`;
             }
             return mainPart;
@@ -224,8 +224,8 @@ export function tsBigIntFromSchema(
     isUnsigned: boolean,
     _context: CodegenContext,
 ): TsProperty {
-    const typeName = schema.nullable ? `bigint | null` : `bigint`;
-    const defaultValue = schema.nullable ? `null` : 'BigInt(0)';
+    const typeName = schema.isNullable ? `bigint | null` : `bigint`;
+    const defaultValue = schema.isNullable ? `null` : 'BigInt(0)';
     return {
         typeName,
         defaultValue,
@@ -233,7 +233,7 @@ export function tsBigIntFromSchema(
             const mainPart = isUnsigned
                 ? `typeof ${input} === 'bigint' && ${input} >= BigInt(0) && ${input} <= UINT64_MAX`
                 : `typeof ${input} === 'bigint' && ${input} >= INT64_MIN && ${input} <= INT64_MAX`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `((${mainPart}) || ${input} === null)`;
             }
             return mainPart;
@@ -258,7 +258,7 @@ export function tsBigIntFromSchema(
             }`;
         },
         toJsonTemplate(input, target) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (typeof ${input} === 'bigint') {
                     ${target} += \`"\${${input}}"\`
                 } else {

--- a/languages/ts/ts-codegen/src/record.ts
+++ b/languages/ts/ts-codegen/src/record.ts
@@ -21,15 +21,15 @@ export function tsRecordFromSchema(
         rpcGenerators: context.rpcGenerators,
     });
     const typeName = `Record<string, ${innerType.typeName}>`;
-    const defaultValue = schema.nullable ? 'null' : '{}';
+    const defaultValue = schema.isNullable ? 'null' : '{}';
     return {
-        typeName: schema.nullable ? `${typeName} | null` : typeName,
+        typeName: schema.isNullable ? `${typeName} | null` : typeName,
         defaultValue,
         validationTemplate(input) {
             const mainPart = `isObject(${input}) && Object.values(${input}).every(
                 (_value) => ${innerType.validationTemplate('_value')},
             )`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `((${mainPart}) || ${input} === null)`;
             }
             return mainPart;
@@ -48,7 +48,7 @@ export function tsRecordFromSchema(
         },
         toJsonTemplate(input, target, key) {
             const countVal = `_${validVarName(key)}PropertyCount`;
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (${input} !== null) {
                     ${target} += '{';
                     let ${countVal} = 0;

--- a/languages/ts/ts-codegen/src/ref.ts
+++ b/languages/ts/ts-codegen/src/ref.ts
@@ -8,14 +8,16 @@ export function tsRefFromSchema(
 ): TsProperty {
     const typeName = pascalCase(validVarName(schema.ref), { normalize: true });
     const prefixedTypeName = `${context.typePrefix}${typeName}`;
-    const defaultValue = schema.nullable ? 'null' : `${prefixedTypeName}.new()`;
+    const defaultValue = schema.isNullable
+        ? 'null'
+        : `${prefixedTypeName}.new()`;
     return {
-        typeName: schema.nullable
+        typeName: schema.isNullable
             ? `${prefixedTypeName} | null`
             : prefixedTypeName,
         defaultValue,
         validationTemplate(input) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `($$${prefixedTypeName}.validate(${input}) || ${input} === null)`;
             }
             return `$$${prefixedTypeName}.validate(${input})`;
@@ -28,7 +30,7 @@ export function tsRefFromSchema(
                 }`;
         },
         toJsonTemplate(input, target, _key) {
-            if (schema.nullable) {
+            if (schema.isNullable) {
                 return `if (${input} !== null) {
                     ${target} += $$${prefixedTypeName}.toJsonString(${input});
                 } else {

--- a/languages/ts/ts-schema/src/compile.ts
+++ b/languages/ts/ts-schema/src/compile.ts
@@ -258,7 +258,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
         switch (schema.type) {
             case 'float32':
             case 'float64':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn: nullableFloatDecoder,
                         code,
@@ -274,7 +274,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                         return bigIntDecoder(
                             input,
                             false,
-                            schema.nullable ?? false,
+                            schema.isNullable ?? false,
                             context,
                         );
                     },
@@ -286,14 +286,14 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                         return bigIntDecoder(
                             input,
                             true,
-                            schema.nullable ?? false,
+                            schema.isNullable ?? false,
                             context,
                         );
                     },
                     code,
                 };
             case 'int32':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input, context) {
                             return nullableIntDecoder(
@@ -313,7 +313,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                     code,
                 };
             case 'int16':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input, context) {
                             return nullableIntDecoder(
@@ -333,7 +333,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                     code,
                 };
             case 'int8':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input, context) {
                             return nullableIntDecoder(
@@ -353,7 +353,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                     code,
                 };
             case 'uint32':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input, context) {
                             return nullableIntDecoder(
@@ -373,7 +373,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                     code,
                 };
             case 'uint16':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input, context) {
                             return nullableIntDecoder(
@@ -393,7 +393,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                     code,
                 };
             case 'uint8':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input, context) {
                             return nullableIntDecoder(
@@ -414,7 +414,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                 };
             case 'boolean':
                 if (shouldCoerce) {
-                    if (schema.nullable) {
+                    if (schema.isNullable) {
                         return {
                             code,
                             fn(input, context) {
@@ -476,7 +476,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                         },
                     };
                 }
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         code,
                         fn(input, context) {
@@ -529,7 +529,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                     code,
                 };
             case 'string':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input, context) {
                             if (typeof input === 'string') {
@@ -567,7 +567,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                 };
             case 'timestamp':
                 if (shouldCoerce) {
-                    if (schema.nullable) {
+                    if (schema.isNullable) {
                         return {
                             fn(input, context) {
                                 if (typeof input === 'string') {
@@ -638,7 +638,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
                         code,
                     };
                 }
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input, context) {
                             if (typeof input === 'string') {
@@ -697,7 +697,7 @@ export function getCompiledParser<TSchema extends ASchema<any>>(
         }
     }
     if (isSchemaFormEnum(schema)) {
-        if (schema.nullable) {
+        if (schema.isNullable) {
             return {
                 fn(input, context) {
                     if (typeof input === 'string') {
@@ -961,7 +961,7 @@ export function getCompiledSerializer<TSchema extends ASchema>(
     if (isSchemaFormType(schema)) {
         switch (schema.type) {
             case 'string':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input: string | null) {
                             if (typeof input === 'string') {
@@ -979,7 +979,7 @@ export function getCompiledSerializer<TSchema extends ASchema>(
                     code,
                 };
             case 'timestamp':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input: Date | null) {
                             if (typeof input === 'object' && input !== null) {
@@ -997,7 +997,7 @@ export function getCompiledSerializer<TSchema extends ASchema>(
                     code,
                 };
             case 'boolean':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input: boolean | null) {
                             if (typeof input === 'boolean') {
@@ -1022,7 +1022,7 @@ export function getCompiledSerializer<TSchema extends ASchema>(
             case 'uint8':
             case 'uint16':
             case 'uint32':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input: number) {
                             if (typeof input === 'number') {
@@ -1041,7 +1041,7 @@ export function getCompiledSerializer<TSchema extends ASchema>(
                 };
             case 'int64':
             case 'uint64':
-                if (schema.nullable) {
+                if (schema.isNullable) {
                     return {
                         fn(input: bigint | null) {
                             if (typeof input === 'bigint') {
@@ -1061,7 +1061,7 @@ export function getCompiledSerializer<TSchema extends ASchema>(
         }
     }
     if (isSchemaFormEnum(schema)) {
-        if (schema.nullable) {
+        if (schema.isNullable) {
             return {
                 fn(input: string | null) {
                     if (

--- a/languages/ts/ts-schema/src/compiler/parse.test.ts
+++ b/languages/ts/ts-schema/src/compiler/parse.test.ts
@@ -183,7 +183,7 @@ it('respects the strict option', () => {
                 id: a.string(),
                 name: a.string(),
             },
-            { strict: true },
+            { isStrict: true },
         ),
     );
     const input = {

--- a/languages/ts/ts-schema/src/compiler/parse.ts
+++ b/languages/ts/ts-schema/src/compiler/parse.ts
@@ -177,7 +177,7 @@ export function booleanTemplate(input: TemplateInput<SchemaFormType>): string {
             else if (${input.val} === false || ${input.val} === 'false' || ${input.val} === 'FALSE' || ${input.val} === 0 || ${input.val} === '0') {
                 ${input.targetVal} = false;
             }`);
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             templateParts.push(`else if (${input.val} === null || ${input.val} === 'null') {
                     ${input.targetVal} = null;
                 }`);
@@ -197,7 +197,7 @@ export function booleanTemplate(input: TemplateInput<SchemaFormType>): string {
             if (${input.val} === 'false') {
                 ${input.targetVal} = false;
             }`);
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             templateParts.push(`if (${input.val} === 'null') {
                 ${input.targetVal} = null;
             }`);
@@ -212,7 +212,7 @@ export function booleanTemplate(input: TemplateInput<SchemaFormType>): string {
     } else {
         $fallback("${input.instancePath}", "${input.schemaPath}/type", "${errorMessage}");
     }`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         templateParts.push(`if (${input.val} === null) {
             ${input.targetVal} = null;
         } else {
@@ -231,7 +231,7 @@ export function stringTemplate(input: TemplateInput<SchemaFormType>): string {
     } else {
         $fallback("${input.instancePath}", "${input.schemaPath}/type", "${errorMessage}");
     }`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (${input.val} === null) {
             ${input.targetVal} = ${input.val};
         } else {
@@ -256,7 +256,7 @@ export function floatTemplate(input: TemplateInput<SchemaFormType>): string {
             if (!Number.isNaN(${valName})) {
                 ${input.targetVal} = ${valName};
             }`);
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             templateParts.push(`else if (${input.val} === 'null') {
                 ${input.targetVal} = null;
             }`);
@@ -274,7 +274,7 @@ export function floatTemplate(input: TemplateInput<SchemaFormType>): string {
     } else {
         $fallback("${input.instancePath}", "${input.schemaPath}/type", "${errorMessage}");
     }`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         templateParts.push(`${input.instancePath.length === 0 || input.shouldCoerce ? 'else ' : ''}if (${input.val} === null) {
             ${input.targetVal} = null;
         } else {
@@ -301,7 +301,7 @@ export function intTemplate(
             if (Number.isInteger(parsedVal) && parsedVal >= ${min} && parsedVal <= ${max}) {
                 ${input.targetVal} = parsedVal;
             }`);
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             templateParts.push(`else if (${input.val} === 'null') {
                 ${input.targetVal} = null;
             }`);
@@ -319,7 +319,7 @@ export function intTemplate(
             $fallback("${input.instancePath}", "${input.schemaPath}", "Expected valid integer between ${min} and ${max}");
         }`;
     const prefix = shouldCoerce ? `else ` : '';
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         templateParts.push(`${prefix}if (${input.val} === null) {
             ${input.targetVal} = null;
         } else {
@@ -341,7 +341,7 @@ export function bigIntTemplate(
     );
     if (
         (input.instancePath.length === 0 || input.shouldCoerce) &&
-        input.schema.nullable
+        input.schema.isNullable
     ) {
         templateParts.push(`if (${input.val} === 'null') {
             ${input.targetVal} = null;
@@ -363,7 +363,7 @@ export function bigIntTemplate(
     }`);
     if (
         (input.instancePath.length === 0 || input.shouldCoerce) &&
-        input.schema.nullable
+        input.schema.isNullable
     ) {
         templateParts.push('}');
     }
@@ -381,7 +381,7 @@ export function bigIntTemplate(
             ${input.targetVal} = ${input.val};
         }`);
     }
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         templateParts.push(`else if (${input.val} === null) {
             ${input.targetVal} = null;
         }`);
@@ -401,7 +401,7 @@ export function timestampTemplate(input: TemplateInput<SchemaFormType>) {
                 if (!Number.isNaN(parsedVal.getMonth())) {
                     ${input.targetVal} = parsedVal;
                 } ${
-                    input.schema.nullable
+                    input.schema.isNullable
                         ? `else if (${input.val} === 'null') {
                                 ${input.targetVal} = null;
                             }`
@@ -422,7 +422,7 @@ export function timestampTemplate(input: TemplateInput<SchemaFormType>) {
         } else if (typeof ${input.val} === 'object' && ${input.val} instanceof Date) {
             ${input.targetVal} = ${input.val};
         }${
-            input.schema.nullable
+            input.schema.isNullable
                 ? ` else if (${input.val} === null) {
                     ${input.targetVal} = null;    
                 }`
@@ -437,7 +437,7 @@ export function timestampTemplate(input: TemplateInput<SchemaFormType>) {
             if (!Number.isNaN(parsedVal.getMonth())) {
                 ${input.targetVal} = parsedVal;
             }`);
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             templateParts.push(`if (${input.val} === 'null') {
                 ${input.targetVal} = null;
             }`);
@@ -454,7 +454,7 @@ export function timestampTemplate(input: TemplateInput<SchemaFormType>) {
     } else {
         $fallback("${input.instancePath}", "${input.schemaPath}", "Expected instanceof Date or ISO Date string")
     }`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         templateParts.push(`if (${input.val} === null) {
             ${input.targetVal} = null
         } else {
@@ -479,7 +479,7 @@ export function enumTemplate(input: TemplateInput<SchemaFormEnum>): string {
             ${input.targetVal} = ${input.val};
         }
     `);
-    if (input.instancePath.length === 0 && input.schema.nullable) {
+    if (input.instancePath.length === 0 && input.schema.isNullable) {
         templateParts.push(`else if (${input.val} === 'null') {
             ${input.targetVal} = null;
         }`);
@@ -493,7 +493,7 @@ export function enumTemplate(input: TemplateInput<SchemaFormEnum>): string {
     }`,
     );
     const mainTemplate = templateParts.join('\n');
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (${input.val} === null) {
             ${input.targetVal} = null;
         } else {
@@ -512,7 +512,7 @@ function objectTemplate(input: TemplateInput<SchemaFormProperties>): string {
             `${innerTargetVal}.${input.discriminatorKey} = "${input.discriminatorValue}";`,
         );
     }
-    if (input.schema.strict) {
+    if (input.schema.isStrict) {
         const keyVal = `_${depthStr}_keys`;
         const optionalKeyVal = `_${depthStr}_optionalKeys`;
         const keys = Object.keys(input.schema.properties)
@@ -595,7 +595,7 @@ function objectTemplate(input: TemplateInput<SchemaFormProperties>): string {
         }
         mainTemplate = `${input.targetVal} = ${fnName}(${input.val});`;
     }
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (${input.val} === null) {
             ${input.targetVal} = null;
         } else {
@@ -632,7 +632,7 @@ export function arrayTemplate(
         $fallback("${input.instancePath}", "${input.schemaPath}", "Expected Array");
     }`;
 
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (${input.val} === null) {
             ${input.targetVal} = null;
         } else {
@@ -702,7 +702,7 @@ export function discriminatorTemplate(
         }
         mainTemplate = `${input.targetVal} = ${fnName}(${input.val});`;
     }
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (${input.val} === null) {
             ${input.targetVal} = null;
         } else {
@@ -743,7 +743,7 @@ export function recordTemplate(input: TemplateInput<SchemaFormValues>): string {
     } else {
         $fallback("${input.instancePath}", "${input.schemaPath}", "Expected object.");
     }`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (${input.val} === null) {
             ${input.targetVal} = null;
         } else {
@@ -762,7 +762,7 @@ export function refTemplate(input: TemplateInput<SchemaFormRef>): string {
     if (!Object.keys(input.subFunctions).includes(fnName)) {
         input.subFunctions[fnName] = '';
     }
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (${input.val} === null) {
             ${input.targetVal} = null;
         } else {

--- a/languages/ts/ts-schema/src/compiler/serialize.ts
+++ b/languages/ts/ts-schema/src/compiler/serialize.ts
@@ -117,7 +117,7 @@ export function stringTemplate(
     input: SerializeTemplateInput<SchemaFormType>,
 ): string {
     if (input.instancePath.length === 0) {
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             return `if (typeof ${input.val} === 'string') {
                 return ${input.val};
             }
@@ -157,7 +157,7 @@ if (${input.val}.length < 42) {
 } else {
     ${input.targetVal} += JSON.stringify(${input.val});
 }`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (typeof ${input.val} === 'string') {
             ${mainTemplate}
         } else {
@@ -174,7 +174,7 @@ export function booleanTemplate(
         return `return \`\${${input.val}}\`;`;
     }
     const mainTemplate = `${input.targetVal} += \`${input.outputPrefix}\${${input.val}}\`;`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (typeof ${input.val} === 'boolean') {
             ${mainTemplate}
         } else {
@@ -188,7 +188,7 @@ export function timestampTemplate(
     input: SerializeTemplateInput<SchemaFormType>,
 ): string {
     if (input.instancePath.length === 0) {
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             return `if (typeof ${input.val} === 'object' && ${input.val} instanceof Date) {
                 return ${input.val}.toISOString();
             }
@@ -197,7 +197,7 @@ export function timestampTemplate(
         return `return ${input.val}.toISOString();`;
     }
     const mainTemplate = `${input.targetVal} += \`${input.outputPrefix}"\${${input.val}.toISOString()}"\`;`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (typeof ${input.val} === 'object' && ${input.val} instanceof Date) {
             ${mainTemplate}
         } else {
@@ -211,7 +211,7 @@ export function numberTemplate(
     input: SerializeTemplateInput<SchemaFormType>,
 ): string {
     if (input.instancePath.length === 0) {
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             return `if (typeof ${input.val} === 'number' && !Number.isNaN(${input.val})) {
                 return \`\${${input.val}}\`;
             }
@@ -224,7 +224,7 @@ export function numberTemplate(
         throw new Error("Expected number at ${input.instancePath} got NaN");
     }
     ${input.targetVal} += \`${input.outputPrefix}\${${input.val}}\`;`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (typeof ${input.val} === 'number' && !Number.isNaN(${input.val})) {
             ${mainTemplate}
         } else {
@@ -238,7 +238,7 @@ export function bigIntTemplate(
     input: SerializeTemplateInput<SchemaFormType>,
 ): string {
     if (input.instancePath.length === 0) {
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             return `if (typeof ${input.val} === 'bigint') {
                 return ${input.val}.toString();
             }
@@ -247,7 +247,7 @@ export function bigIntTemplate(
         return `return ${input.val}.toString();`;
     }
     const mainTemplate = `${input.targetVal} += \`${input.outputPrefix}"\${${input.val}.toString()}"\`;`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (typeof ${input.val} === 'bigint') {
             ${mainTemplate}
         } else {
@@ -261,7 +261,7 @@ export function enumTemplate(
     input: SerializeTemplateInput<SchemaFormEnum>,
 ): string {
     if (input.instancePath.length === 0) {
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             return `if (typeof ${input.val} === 'string') {
                 return ${input.val};
             }
@@ -270,7 +270,7 @@ export function enumTemplate(
         return `return ${input.val};`;
     }
     const mainTemplate = `${input.targetVal} += \`${input.outputPrefix}"\${${input.val}}"\``;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (typeof ${input.val} === 'string') {
             ${mainTemplate}
         } else {
@@ -405,7 +405,7 @@ export function objectTemplate(
         }
         mainTemplate = `${fnName}(${input.val});`;
     }
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (typeof ${input.val} === 'object' && ${input.val} !== null) {
             ${input.targetVal} += '${input.outputPrefix}';
             ${mainTemplate.split('___val___').join(input.val)}
@@ -453,7 +453,7 @@ export function arrayTemplate(
     }`);
     templateParts.push(`${input.targetVal} += ']';`);
     const mainTemplate = templateParts.join('\n');
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (Array.isArray(${input.val})) {
             ${mainTemplate}
         } else {
@@ -525,7 +525,7 @@ export function recordTemplate(
     }`);
     templateParts.push(`${input.targetVal} += '}';`);
     const mainTemplate = templateParts.join('\n');
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (typeof ${input.val} === 'object' && ${input.val} !== null) {
             ${mainTemplate}
         } else {
@@ -574,7 +574,7 @@ function discriminatorTemplate(
         mainTemplate = `${fnName}(${input.val});`;
     }
 
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (typeof ${input.val} === 'object' && ${input.val} !== null) {
             ${mainTemplate.split(inputPlaceholder).join(input.val)}
         } else {
@@ -591,7 +591,7 @@ export function anyTemplate(
         const mainTemplate = `if (typeof ${input.val} !== 'undefined') {
             ${input.targetVal} += '${input.outputPrefix}' + JSON.stringify(${input.val});
         }`;
-        if (input.schema.nullable) {
+        if (input.schema.isNullable) {
             return `if (${input.val} === null) {
                 ${input.targetVal} += '${input.outputPrefix}null';
             } else {
@@ -616,7 +616,7 @@ export function refTemplate(
     if (!Object.keys(input.subFunctions).includes(fnName)) {
         input.subFunctions[fnName] = '';
     }
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `if (${input.val} === null) {
             ${input.targetVal} += '${input.outputPrefix}null';
         } else {

--- a/languages/ts/ts-schema/src/compiler/validate.test.ts
+++ b/languages/ts/ts-schema/src/compiler/validate.test.ts
@@ -469,7 +469,7 @@ it('uses strict properly', () => {
                 id: a.string(),
                 name: a.string(),
             },
-            { strict: true },
+            { isStrict: true },
         ),
     );
     const input = {

--- a/languages/ts/ts-schema/src/compiler/validate.ts
+++ b/languages/ts/ts-schema/src/compiler/validate.ts
@@ -110,7 +110,7 @@ function schemaTemplate(input: TemplateInput): string {
 function booleanTemplate(
     input: TemplateInput<AScalarSchema<'boolean'>>,
 ): string {
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `(${input.val} === null || typeof ${input.val} === 'boolean')`;
     }
     return `typeof ${input.val} === 'boolean'`;
@@ -119,7 +119,7 @@ function booleanTemplate(
 function floatTemplate(
     input: TemplateInput<AScalarSchema<'float32' | 'float64'>>,
 ): string {
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `((typeof ${input.val} === 'number' && !Number.isNaN(${input.val})) || ${input.val} === null)`;
     }
     return `(typeof ${input.val} === 'number' && !Number.isNaN(${input.val}))`;
@@ -134,7 +134,7 @@ function intTemplate(
     min: number,
     max: number,
 ): string {
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `((typeof ${input.val} === 'number' && Number.isInteger(${input.val}) && ${input.val} >= ${min} && ${input.val} <= ${max}) || ${input.val} === null)`;
     }
     return `(typeof ${input.val} === 'number' && Number.isInteger(${input.val}) && ${input.val} >= ${min} && ${input.val} <= ${max})`;
@@ -147,14 +147,14 @@ function bigIntTemplate(
     const mainTemplate = isUnsigned
         ? `typeof ${input.val} === 'bigint' && ${input.val} >= BigInt("0")`
         : `typeof ${input.val} === 'bigint' && ${input.val} < BigInt("9223372036854775808") && ${input.val} > BigInt("-9223372036854775809")`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `(${mainTemplate}) || ${input.val} === null`;
     }
     return mainTemplate;
 }
 
 function stringTemplate(input: TemplateInput<AScalarSchema<'string'>>): string {
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `(typeof ${input.val} === 'string' || ${input.val} === null)`;
     }
     return `typeof ${input.val} === 'string'`;
@@ -163,7 +163,7 @@ function stringTemplate(input: TemplateInput<AScalarSchema<'string'>>): string {
 function timestampTemplate(
     input: TemplateInput<AScalarSchema<'timestamp'>>,
 ): string {
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `((typeof ${input.val} === 'object' && ${input.val} instanceof Date) || ${input.val} === null)`;
     }
     return `typeof ${input.val} === 'object' && ${input.val}  instanceof Date`;
@@ -178,7 +178,7 @@ function objectTemplate(input: TemplateInput<AObjectSchema<any>>): string {
     } else {
         parts.push(`typeof ${input.val} === 'object' && ${input.val} !== null`);
     }
-    if (input.schema.strict) {
+    if (input.schema.isStrict) {
         const allowedKeys = Object.keys(input.schema.properties);
         for (const key of Object.keys(input.schema.optionalProperties ?? {})) {
             allowedKeys.push(key);
@@ -229,7 +229,7 @@ function objectTemplate(input: TemplateInput<AObjectSchema<any>>): string {
         mainTemplate = `${fnName}(${input.val})`;
     }
 
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `((${mainTemplate}) || ${input.val} === null)`;
     }
 
@@ -242,7 +242,7 @@ function enumTemplate(
     const enumPart = input.schema.enum
         .map((val) => `${input.val} === "${val}"`)
         .join(' || ');
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `((typeof ${input.val} === 'string' && (${enumPart})) || ${input.val} === null)`;
     }
     return `(typeof ${input.val} === 'string' && (${enumPart}))`;
@@ -259,7 +259,7 @@ function arrayTemplate(input: TemplateInput<AArraySchema<any>>) {
         shouldCoerce: undefined,
     });
 
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `((Array.isArray(${input.val}) && ${input.val}.every((item) => ${innerTemplate})) || ${input.val} === null)`;
     }
     return `(Array.isArray(${input.val}) && ${input.val}.every((item) => ${innerTemplate}))`;
@@ -276,7 +276,7 @@ function recordTemplate(input: TemplateInput<ARecordSchema<any>>): string {
         shouldCoerce: undefined,
     });
     const mainTemplate = `typeof ${input.val} === 'object' && ${input.val} !== null && Object.keys(${input.val}).every((key) => ${subTemplate})`;
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `((${mainTemplate}) || ${input.val} === null)`;
     }
     return mainTemplate;
@@ -319,7 +319,7 @@ function discriminatorTemplate(
         mainTemplate = `${fnName}(${input.val})`;
     }
 
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `((${mainTemplate}) || ${input.val} === null)`;
     }
     return mainTemplate;
@@ -334,7 +334,7 @@ function refTemplate(input: TemplateInput<ARefSchema<any>>) {
     if (!Object.keys(input.subFunctions).includes(fnName)) {
         input.subFunctions[fnName] = '';
     }
-    if (input.schema.nullable) {
+    if (input.schema.isNullable) {
         return `(${input.val} === null || ${fnName}(${input.val}))`;
     }
     return `${fnName}(${input.val})`;

--- a/languages/ts/ts-schema/src/lib/modifiers.test.ts
+++ b/languages/ts/ts-schema/src/lib/modifiers.test.ts
@@ -156,7 +156,7 @@ describe('nullable()', () => {
         const result = JSON.parse(JSON.stringify(a.nullable(a.boolean())));
         expect(result).toStrictEqual({
             type: 'boolean',
-            nullable: true,
+            isNullable: true,
             metadata: {},
         });
     });

--- a/languages/ts/ts-schema/src/lib/modifiers.ts
+++ b/languages/ts/ts-schema/src/lib/modifiers.ts
@@ -72,7 +72,7 @@ export function nullable<T = any, TOptional extends boolean = false>(
     };
     const result: ASchemaWithAdapters<T | null, TOptional> = {
         ...schema,
-        nullable: true,
+        isNullable: true,
         metadata: {
             id: opts.id ?? schema.metadata?.id,
             description: opts.description ?? schema.metadata?.description,

--- a/languages/ts/ts-schema/src/lib/object.test.ts
+++ b/languages/ts/ts-schema/src/lib/object.test.ts
@@ -529,7 +529,7 @@ describe('a.pick()', () => {
 
 describe('a.omit()', () => {
     const UserSubsetSchema = a.omit(UserSchema, ['id', 'isAdmin'], {
-        strict: true,
+        isStrict: true,
     });
     type UserSubsetSchema = a.infer<typeof UserSubsetSchema>;
     const parse = (input: unknown) => a.parse(UserSubsetSchema, input);

--- a/languages/ts/ts-schema/src/lib/object.test.ts
+++ b/languages/ts/ts-schema/src/lib/object.test.ts
@@ -224,7 +224,7 @@ describe('a.object()', () => {
                 name: {
                     type: 'string',
                     metadata: {},
-                    nullable: true,
+                    isNullable: true,
                 },
                 createdAt: {
                     type: 'timestamp',
@@ -480,7 +480,7 @@ describe('a.pick()', () => {
                 email: {
                     type: 'string',
                     metadata: {},
-                    nullable: true,
+                    isNullable: true,
                 },
             },
             optionalProperties: {},
@@ -576,7 +576,7 @@ describe('a.omit()', () => {
                 email: {
                     type: 'string',
                     metadata: {},
-                    nullable: true,
+                    isNullable: true,
                 },
             },
             optionalProperties: {
@@ -585,7 +585,7 @@ describe('a.omit()', () => {
                     metadata: {},
                 },
             },
-            strict: true,
+            isStrict: true,
             metadata: {},
         });
     });
@@ -742,7 +742,7 @@ describe('a.partial()', () => {
                 name: {
                     type: 'string',
                     metadata: {},
-                    nullable: true,
+                    isNullable: true,
                 },
                 createdAt: {
                     type: 'timestamp',

--- a/languages/ts/ts-schema/src/lib/object.ts
+++ b/languages/ts/ts-schema/src/lib/object.ts
@@ -60,8 +60,8 @@ export function object<
     const schema: SchemaFormProperties = {
         properties: {},
     };
-    if (typeof options.strict === 'boolean') {
-        schema.strict = options.strict;
+    if (typeof options.isStrict === 'boolean') {
+        schema.isStrict = options.isStrict;
     }
     for (const key of Object.keys(input)) {
         const prop = input[key]!;
@@ -156,7 +156,7 @@ export function decodeObjectSchema<T>(
     const inputKeys = Object.keys(parsedInput);
     const requiredKeys = Object.keys(schema.properties);
     const optionalKeys = Object.keys(optionalProps);
-    if (schema.strict) {
+    if (schema.isStrict) {
         for (const key of inputKeys) {
             if (
                 !requiredKeys.includes(key) &&
@@ -253,7 +253,7 @@ export function validateObjectSchema(
     if (!isObject(input)) {
         return false;
     }
-    const allowedKeys: string[] | undefined = schema.strict ? [] : undefined;
+    const allowedKeys: string[] | undefined = schema.isStrict ? [] : undefined;
     for (const key of Object.keys(schema.properties)) {
         const propSchema = schema.properties[key]!;
         const isValid = propSchema[VALIDATOR_KEY].validate(input[key]);
@@ -300,10 +300,10 @@ export function pick<
     type TOutput = Pick<InferType<TSchema>, TKeys>;
     const schema: SchemaFormProperties = {
         properties: {},
-        nullable: inputSchema.nullable,
+        isNullable: inputSchema.isNullable,
     };
-    if (typeof options.strict === 'boolean') {
-        schema.strict = options.strict;
+    if (typeof options.isStrict === 'boolean') {
+        schema.isStrict = options.isStrict;
     }
 
     Object.keys(inputSchema.properties).forEach((key) => {
@@ -391,10 +391,10 @@ export function omit<
         properties: {
             ...inputSchema.properties,
         },
-        nullable: inputSchema.nullable,
+        isNullable: inputSchema.isNullable,
     };
-    if (typeof options.strict === 'boolean') {
-        schema.strict = options.strict;
+    if (typeof options.isStrict === 'boolean') {
+        schema.isStrict = options.isStrict;
     }
     Object.keys(inputSchema.properties).forEach((key) => {
         if (keys.includes(key as any)) {
@@ -522,8 +522,8 @@ export function extend<
             description: options.description,
         },
     };
-    if (typeof options.strict === 'boolean') {
-        schema.strict = options.strict;
+    if (typeof options.isStrict === 'boolean') {
+        schema.isNullable = options.isStrict;
     }
 
     const isType = (
@@ -566,14 +566,14 @@ export function partial<
     const newSchema: SchemaFormProperties = {
         properties: {},
         optionalProperties: {},
-        nullable: schema.nullable,
+        isNullable: schema.isNullable,
         metadata: {
             id: options.id,
             description: options.description,
         },
     };
-    if (typeof options.strict === 'boolean') {
-        schema.strict = options.strict;
+    if (typeof options.isStrict === 'boolean') {
+        schema.isStrict = options.isStrict;
     }
     for (const key of Object.keys(schema.properties)) {
         const prop = schema.properties[key]!;

--- a/languages/ts/ts-schema/src/lib/recursive.test.ts
+++ b/languages/ts/ts-schema/src/lib/recursive.test.ts
@@ -240,12 +240,12 @@ it('produces valid ATD', () => {
         properties: {
             left: {
                 ref: 'BinaryTree',
-                nullable: true,
+                isNullable: true,
                 metadata: {},
             },
             right: {
                 ref: 'BinaryTree',
-                nullable: true,
+                isNullable: true,
                 metadata: {},
             },
         },

--- a/languages/ts/ts-schema/src/lib/validation.test.ts
+++ b/languages/ts/ts-schema/src/lib/validation.test.ts
@@ -187,7 +187,7 @@ describe('errors()', () => {
                 id: a.string(),
                 date: a.timestamp(),
             },
-            { strict: true },
+            { isStrict: true },
         );
         const looseResult = a.errors(looseSchema, {
             id: '1',

--- a/languages/ts/ts-schema/src/schemas.ts
+++ b/languages/ts/ts-schema/src/schemas.ts
@@ -68,7 +68,7 @@ export type WithAdapters<T = any> = StandardSchemaV1<T>;
 
 export interface ASchema<T = any, TOptional extends boolean = false> {
     metadata?: SchemaMetadata;
-    nullable?: boolean;
+    isNullable?: boolean;
     [VALIDATOR_KEY]: SchemaValidator<T, TOptional>;
 }
 export type ASchemaStrict<TSchema extends ASchema> = Omit<
@@ -250,7 +250,7 @@ export interface AObjectSchema<TVal = any, TStrict extends boolean = false>
     extends ASchema<TVal> {
     properties: Record<string, ASchema>;
     optionalProperties?: Record<string, ASchema>;
-    strict?: TStrict;
+    isStrict?: TStrict;
 }
 export function isAObjectSchema(input: unknown): input is AObjectSchema {
     return isASchema(input) && isSchemaFormProperties(input);
@@ -265,7 +265,7 @@ export interface AObjectSchemaOptions<TAdditionalProps extends boolean = false>
     /**
      * Allow this object to include additional properties not specified here
      */
-    strict?: TAdditionalProps;
+    isStrict?: TAdditionalProps;
 }
 
 // object helper types

--- a/languages/ts/ts-schema/src/testSuites.ts
+++ b/languages/ts/ts-schema/src/testSuites.ts
@@ -756,7 +756,7 @@ export const validationTestSuites: Record<
                 id: a.string(),
                 name: a.string(),
             },
-            { strict: true },
+            { isStrict: true },
         ),
         goodInputs: [
             {
@@ -786,7 +786,7 @@ export const validationTestSuites: Record<
                 id: a.string(),
                 name: a.string(),
             },
-            { strict: false },
+            { isStrict: false },
         ),
         goodInputs: [
             {

--- a/specifications/arri_type_definition.md
+++ b/specifications/arri_type_definition.md
@@ -6,9 +6,9 @@ This documents defines the Arri Type Definition (ATD) specification for Arri RPC
 
 ## Table of Contents
 
--   [Goals](#goals)
--   [Schema Forms](#schema-forms)
--   [Global Keywords](#global-keywords)
+- [Goals](#goals)
+- [Schema Forms](#schema-forms)
+- [Global Keywords](#global-keywords)
 
 ## Goals
 
@@ -20,14 +20,14 @@ ATD schemas are not intended to be written by hand. Their intended workflow is t
 
 Arri Type Definitions are JSON documents that can take on one of eight forms.
 
--   The [empty form](#empty-schema-form)
--   The [type form](#type-schema-form)
--   The [enum form](#enum-schema-form)
--   The [elements form](#elements-schema-form)
--   The [properties form](#properties-schema-form)
--   The [values form](#values-schema-form)
--   The [discriminator form](#discriminator-schema-form)
--   The [ref form](#ref-schema-form)
+- The [empty form](#empty-schema-form)
+- The [type form](#type-schema-form)
+- The [enum form](#enum-schema-form)
+- The [elements form](#elements-schema-form)
+- The [properties form](#properties-schema-form)
+- The [values form](#values-schema-form)
+- The [discriminator form](#discriminator-schema-form)
+- The [ref form](#ref-schema-form)
 
 ### "Empty" Schema Form
 
@@ -150,7 +150,7 @@ However the following input is not valid:
 
 #### Strict Mode
 
-By default, **properties / optionalProperties** will accept inputs with "extra" properties not mentioned explicitly in the schema. If you need to reject inputs that have any properties not mentioned explicitly in the schema you can use **"strict": true**. For example:
+By default, **properties / optionalProperties** will accept inputs with "extra" properties not mentioned explicitly in the schema. If you need to reject inputs that have any properties not mentioned explicitly in the schema you can use **"isStrict": true**. For example:
 
 ```json
 {
@@ -158,7 +158,7 @@ By default, **properties / optionalProperties** will accept inputs with "extra" 
         "name": { "type": "string" },
         "isAdmin": { "type": "boolean" }
     },
-    "strict": true
+    "isStrict": true
 }
 ```
 
@@ -199,8 +199,8 @@ To describe objects that work like a tagged union (aka: "discriminated union", o
 
 A "discriminator" schema has two keywords:
 
--   `discriminator` which tells you what property is the "tag" property
--   `mapping` which tells you what schema to use, based on the value of the "tag" property.
+- `discriminator` which tells you what property is the "tag" property
+- `mapping` which tells you what schema to use, based on the value of the "tag" property.
 
 For example, let's say you have messages that look like this:
 
@@ -286,11 +286,11 @@ Having a recursive schema of a different form is invalid ATD. For example,
     "properties": {
         "left": {
             "ref": "BinaryTree",
-            "nullable": true
+            "isNullable": true
         },
         "right": {
             "ref": "BinaryTree",
-            "nullable": true
+            "isNullable": true
         },
         "metadata": {
             "id": "BinaryTree"
@@ -319,19 +319,19 @@ Accepts
 
 ## Global Keywords
 
-### The `nullable` keyword
+### The `isNullable` keyword
 
-You can put `nullable` on any schema (regardless of which "form" it takes), and that will make `null` an acceptable value for the schema.
+You can put `isNullable` on any schema (regardless of which "form" it takes), and that will make `null` an acceptable value for the schema.
 
 For example,
 
 ```json
-{ "type": "string", "nullable": true }
+{ "type": "string", "isNullable": true }
 ```
 
 Will accept `"foo"` and `null`
 
-Note: you can't put `nullable` on a schema in a [discriminator **mapping**](#discriminator-schema-form). If you want a discriminator to be nullable, you have to put it at the same level as the `discriminator` and `mapping` keywords.
+Note: you can't put `isNullable` on a schema in a [discriminator **mapping**](#discriminator-schema-form). If you want a discriminator to be nullable, you have to put it at the same level as the `discriminator` and `mapping` keywords.
 
 ### The `metadata` keyword
 

--- a/tests/test-files/AppDefinition.json
+++ b/tests/test-files/AppDefinition.json
@@ -208,23 +208,27 @@
     },
     "ObjectWithNullableFields": {
       "properties": {
-        "string": { "type": "string", "metadata": {}, "nullable": true },
-        "boolean": { "type": "boolean", "metadata": {}, "nullable": true },
-        "timestamp": { "type": "timestamp", "metadata": {}, "nullable": true },
-        "float32": { "type": "float32", "metadata": {}, "nullable": true },
-        "float64": { "type": "float64", "metadata": {}, "nullable": true },
-        "int8": { "type": "int8", "metadata": {}, "nullable": true },
-        "uint8": { "type": "uint8", "metadata": {}, "nullable": true },
-        "int16": { "type": "int16", "metadata": {}, "nullable": true },
-        "uint16": { "type": "uint16", "metadata": {}, "nullable": true },
-        "int32": { "type": "int32", "metadata": {}, "nullable": true },
-        "uint32": { "type": "uint32", "metadata": {}, "nullable": true },
-        "int64": { "type": "int64", "metadata": {}, "nullable": true },
-        "uint64": { "type": "uint64", "metadata": {}, "nullable": true },
+        "string": { "type": "string", "metadata": {}, "isNullable": true },
+        "boolean": { "type": "boolean", "metadata": {}, "isNullable": true },
+        "timestamp": {
+          "type": "timestamp",
+          "metadata": {},
+          "isNullable": true
+        },
+        "float32": { "type": "float32", "metadata": {}, "isNullable": true },
+        "float64": { "type": "float64", "metadata": {}, "isNullable": true },
+        "int8": { "type": "int8", "metadata": {}, "isNullable": true },
+        "uint8": { "type": "uint8", "metadata": {}, "isNullable": true },
+        "int16": { "type": "int16", "metadata": {}, "isNullable": true },
+        "uint16": { "type": "uint16", "metadata": {}, "isNullable": true },
+        "int32": { "type": "int32", "metadata": {}, "isNullable": true },
+        "uint32": { "type": "uint32", "metadata": {}, "isNullable": true },
+        "int64": { "type": "int64", "metadata": {}, "isNullable": true },
+        "uint64": { "type": "uint64", "metadata": {}, "isNullable": true },
         "enum": {
           "enum": ["FOO", "BAR", "BAZ"],
           "metadata": { "id": "Enumerator" },
-          "nullable": true
+          "isNullable": true
         },
         "object": {
           "properties": {
@@ -232,17 +236,17 @@
             "content": { "type": "string", "metadata": {} }
           },
           "metadata": { "id": "NestedObject" },
-          "nullable": true
+          "isNullable": true
         },
         "array": {
           "elements": { "type": "boolean", "metadata": {} },
           "metadata": {},
-          "nullable": true
+          "isNullable": true
         },
         "record": {
           "values": { "type": "boolean", "metadata": {} },
           "metadata": {},
-          "nullable": true
+          "isNullable": true
         },
         "discriminator": {
           "discriminator": "typeName",
@@ -268,16 +272,24 @@
             }
           },
           "metadata": { "id": "Discriminator" },
-          "nullable": true
+          "isNullable": true
         },
-        "any": { "metadata": {}, "nullable": true }
+        "any": { "metadata": {}, "isNullable": true }
       },
       "metadata": { "id": "ObjectWithNullableFields" }
     },
     "RecursiveObject": {
       "properties": {
-        "left": { "ref": "RecursiveObject", "nullable": true, "metadata": {} },
-        "right": { "ref": "RecursiveObject", "nullable": true, "metadata": {} }
+        "left": {
+          "ref": "RecursiveObject",
+          "isNullable": true,
+          "metadata": {}
+        },
+        "right": {
+          "ref": "RecursiveObject",
+          "isNullable": true,
+          "metadata": {}
+        }
       },
       "metadata": { "id": "RecursiveObject" }
     }

--- a/tooling/json-schema-to-atd/src/index.test.ts
+++ b/tooling/json-schema-to-atd/src/index.test.ts
@@ -23,7 +23,7 @@ it('Converts integers', () => {
     const expectedOutput: SchemaFormType = {
         type: 'int32',
         metadata: emptyMetadata,
-        nullable: undefined,
+        isNullable: undefined,
     };
     expect(jsonSchemaToJtdSchema(integerSchema)).toStrictEqual(expectedOutput);
 });
@@ -35,7 +35,7 @@ it('Converts strings', () => {
     const expectedOutput: SchemaFormType = {
         type: 'string',
         metadata: emptyMetadata,
-        nullable: undefined,
+        isNullable: undefined,
     };
     expect(jsonSchemaToJtdSchema(input)).toStrictEqual(expectedOutput);
 });
@@ -48,7 +48,7 @@ it('Converts strings that are marked as format "date-time"', () => {
     const expectedOutput: SchemaFormType = {
         type: 'timestamp',
         metadata: emptyMetadata,
-        nullable: undefined,
+        isNullable: undefined,
     };
     expect(jsonSchemaToJtdSchema(input)).toStrictEqual(expectedOutput);
     const input2: JsonSchemaScalarType = {
@@ -59,7 +59,7 @@ it('Converts strings that are marked as format "date-time"', () => {
     const expectedOutput2: SchemaFormType = {
         type: 'timestamp',
         metadata: emptyMetadata,
-        nullable: true,
+        isNullable: true,
     };
     expect(jsonSchemaToJtdSchema(input2)).toStrictEqual(expectedOutput2);
 });
@@ -88,27 +88,27 @@ it('Converts objects', () => {
             id: {
                 type: 'string',
                 metadata: emptyMetadata,
-                nullable: undefined,
+                isNullable: undefined,
             },
             title: {
                 type: 'string',
                 metadata: emptyMetadata,
-                nullable: undefined,
+                isNullable: undefined,
             },
             numLikes: {
                 type: 'int32',
                 metadata: emptyMetadata,
-                nullable: undefined,
+                isNullable: undefined,
             },
             createdAt: {
                 type: 'int32',
                 metadata: emptyMetadata,
-                nullable: undefined,
+                isNullable: undefined,
             },
         },
         metadata: emptyMetadata,
-        strict: undefined,
-        nullable: undefined,
+        isStrict: undefined,
+        isNullable: undefined,
     };
     expect(jsonSchemaToJtdSchema(input)).toStrictEqual(expectedOutput);
 });
@@ -130,7 +130,7 @@ it('Converts objects with optional values', () => {
         properties: {
             id: {
                 type: 'string',
-                nullable: undefined,
+                isNullable: undefined,
                 metadata: emptyMetadata,
             },
         },
@@ -138,12 +138,12 @@ it('Converts objects with optional values', () => {
             name: {
                 type: 'string',
                 metadata: emptyMetadata,
-                nullable: undefined,
+                isNullable: undefined,
             },
         },
         metadata: emptyMetadata,
-        strict: undefined,
-        nullable: undefined,
+        isStrict: undefined,
+        isNullable: undefined,
     };
     expect(jsonSchemaToJtdSchema(input)).toStrictEqual(expectedOutput);
 });
@@ -160,10 +160,10 @@ it('Converts dictionary types', () => {
     const expectedOutput1: SchemaFormValues = {
         values: {
             type: 'string',
-            nullable: undefined,
+            isNullable: undefined,
             metadata: emptyMetadata,
         },
-        nullable: undefined,
+        isNullable: undefined,
         metadata: emptyMetadata,
     };
     expect(jsonSchemaToJtdSchema(input1)).toStrictEqual(expectedOutput1);
@@ -190,21 +190,21 @@ it('Converts dictionary types', () => {
             optionalProperties: {
                 id: {
                     type: 'string',
-                    nullable: undefined,
+                    isNullable: undefined,
                     metadata: emptyMetadata,
                 },
                 name: {
                     type: 'string',
-                    nullable: true,
+                    isNullable: true,
                     metadata: emptyMetadata,
                 },
             },
             metadata: emptyMetadata,
-            nullable: undefined,
-            strict: undefined,
+            isNullable: undefined,
+            isStrict: undefined,
         },
         metadata: emptyMetadata,
-        nullable: undefined,
+        isNullable: undefined,
     };
     expect(jsonSchemaToJtdSchema(input2)).toStrictEqual(expectedOutput2);
 });

--- a/tooling/json-schema-to-atd/src/index.ts
+++ b/tooling/json-schema-to-atd/src/index.ts
@@ -102,39 +102,39 @@ export function jsonSchemaScalarToJtdScalar(
         case 'Date':
             return {
                 type: 'timestamp',
-                nullable: input.nullable,
+                isNullable: input.nullable,
                 metadata: meta,
             };
         case 'bigint':
         case 'integer':
             return {
                 type: 'int32',
-                nullable: input.nullable,
+                isNullable: input.nullable,
                 metadata: meta,
             };
         case 'number':
             return {
                 type: 'float64',
-                nullable: input.nullable,
+                isNullable: input.nullable,
                 metadata: meta,
             };
         case 'boolean':
             return {
                 type: 'boolean',
-                nullable: input.nullable,
+                isNullable: input.nullable,
                 metadata: meta,
             };
         case 'string':
             if (input.format === 'date-time') {
                 return {
                     type: 'timestamp',
-                    nullable: input.nullable,
+                    isNullable: input.nullable,
                     metadata: meta,
                 };
             }
             return {
                 type: 'string',
-                nullable: input.nullable,
+                isNullable: input.nullable,
                 metadata: meta,
             };
         default:
@@ -148,8 +148,8 @@ export function jsonSchemaObjectToJtdObject(
 ): Schema {
     const result: SchemaFormProperties = {
         properties: {},
-        nullable: input.nullable,
-        strict:
+        isNullable: input.nullable,
+        isStrict:
             typeof input.additionalProperties === 'boolean'
                 ? !input.additionalProperties
                 : undefined,
@@ -184,7 +184,7 @@ export function jsonSchemaArrayToJtdArray(
 ) {
     const result: SchemaFormElements = {
         elements: jsonSchemaToJtdSchema(input.items),
-        nullable: input.nullable,
+        isNullable: input.nullable,
         metadata: {
             id: input.$id ?? input.title,
             description: input.description,
@@ -201,7 +201,7 @@ export function jsonSchemaRecordToJtdRecord(
         const type = jsonSchemaToJtdSchema(input.additionalProperties);
         return {
             values: type,
-            nullable: input.nullable,
+            isNullable: input.nullable,
             metadata: {
                 id: input.$id ?? input.title,
                 description: input.description,
@@ -224,7 +224,7 @@ export function jsonSchemaRecordToJtdRecord(
     }
     const result: SchemaFormValues = {
         values: types[0]!,
-        nullable: input.nullable,
+        isNullable: input.nullable,
         metadata: {
             id: input.$id ?? input.title,
             description: input.description,
@@ -242,7 +242,7 @@ export function jsonSchemaRefToJtdRef(
         const refId = parts[parts.length - 1];
         if (!refId) return {};
         return {
-            nullable: input.nullable,
+            isNullable: input.nullable,
             ref: refId,
         };
     }

--- a/tooling/type-defs/src/appDef.ts
+++ b/tooling/type-defs/src/appDef.ts
@@ -69,7 +69,12 @@ export interface RpcDefinitionBase<T = string> {
     response?: T;
     description?: string;
     isDeprecated?: boolean;
+    deprecatedNote?: string;
+    deprecatedSince?: string;
 }
+
+// procedures
+// channels
 
 export interface HttpRpcDefinition<T = string> extends RpcDefinitionBase<T> {
     transport: 'http';

--- a/tooling/type-defs/src/typeDef.ts
+++ b/tooling/type-defs/src/typeDef.ts
@@ -20,14 +20,14 @@ export type Schema =
 export function isSchema(input: unknown): input is Schema {
     const allowedProperties = [
         'metadata',
-        'nullable',
+        'isNullable',
+        'isStrict',
         'type',
         'enum',
         'elements',
         'values',
         'properties',
         'optionalProperties',
-        'strict',
         'discriminator',
         'mapping',
         'ref',
@@ -46,8 +46,8 @@ export function isSchema(input: unknown): input is Schema {
 
 // ANY //
 export interface SchemaFormEmpty {
-    nullable?: boolean;
     metadata?: SchemaMetadata;
+    isNullable?: boolean;
 }
 export function isSchemaFormEmpty(input: unknown): input is SchemaFormEmpty {
     if (!isObject(input)) {
@@ -127,7 +127,7 @@ export function isSchemaFormElements(
 export interface SchemaFormProperties extends SchemaFormEmpty {
     properties: Record<string, Schema>;
     optionalProperties?: Record<string, Schema>;
-    strict?: boolean;
+    isStrict?: boolean;
 }
 export function isSchemaFormProperties(
     input: unknown,


### PR DESCRIPTION
This PR makes it to where every bool property in arri app definition and every bool property in arri type definition is prefixed with `is`

Thus:
- `nullable` has been renamed to `isNullable`
- `strict` has been renamed to `isStrict`

This fixes inconsistencies where we have had:
- `isDeprecated`
- `isEventStream`
- `nullable`
- `strict`