### PR TITLE
fix(rust-codegen): emit nested service struct definitions

### DIFF
--- a/languages/rust/rust-codegen/src/procedures.ts
+++ b/languages/rust/rust-codegen/src/procedures.ts
@@ -147,6 +147,7 @@ export function rustServiceFromSchema(
                     key: validRustIdentifier(key),
                     name: subService.name,
                 });
+                subServiceContent.push(subService.content);
             }
             continue;
         }


### PR DESCRIPTION
## Summary
- Add missing `subServiceContent.push(subService.content)` in `rustServiceFromSchema` to include nested service struct definitions in the generated output

## Problem
When using nested service namespaces (e.g., `v1.updates`, `v1.registry`), the generated Rust code references child service types but never defines them, causing compilation errors.

Fixes #187